### PR TITLE
[Varya] Switch to using add_editor_style to enqueue block editor stylesheets.

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -269,7 +269,7 @@
 	margin-top: var(--global--spacing-vertical);
 }
 
-#wpwrap .editor-styles-wrapper {
+body {
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);
@@ -284,16 +284,16 @@
 	font-size: var(--global--font-size-root);
 }
 
-.editor-styles-wrapper a {
+a {
 	color: var(--global--color-primary);
 }
 
-.editor-styles-wrapper a:hover {
+a:hover {
 	color: var(--global--color-primary-hover);
 }
 
-.editor-styles-wrapper button,
-.editor-styles-wrapper a {
+button,
+a {
 	cursor: pointer;
 }
 
@@ -379,166 +379,166 @@ object {
 	max-width: 100%;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: calc(0.5 * var(--global--spacing-vertical));
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
 	margin-right: var(--global--spacing-vertical);
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
 	margin-left: var(--global--spacing-vertical);
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
 	padding: var(--global--spacing-vertical);
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
 	color: var(--global--color-white);
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .article-section-title {
+.wp-block-a8c-blog-posts .article-section-title {
 	font-size: var(--global--font-size-base);
 	margin-top: 0;
 	margin-bottom: calc(0.5 * var(--global--spacing-vertical));
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts article {
+.wp-block-a8c-blog-posts article {
 	margin-bottom: calc(2 * var(--global--spacing-vertical));
 }
 
 @media only screen and (min-width: 560px) {
-	.editor-styles-wrapper .wp-block-a8c-blog-posts article {
+	.wp-block-a8c-blog-posts article {
 		margin-bottom: calc(3 * var(--global--spacing-vertical));
 	}
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .post-thumbnail img {
+.wp-block-a8c-blog-posts .post-thumbnail img {
 	vertical-align: middle;
 	width: auto;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-wrapper > * {
+.wp-block-a8c-blog-posts .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: var(--global--spacing-unit);
 	margin-bottom: var(--global--spacing-unit);
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
 	margin-top: 0;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
 	margin-bottom: 0;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a {
+.wp-block-a8c-blog-posts .entry-title a {
 	color: var(--global--color-primary);
 }
 
-.has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a,
-[style*="background-color"] .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a {
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a:hover {
+.wp-block-a8c-blog-posts .entry-title a:hover {
 	color: var(--global--color-primary-hover);
 	text-decoration: underline;
 }
 
-.has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a,
-[style*="background-color"] .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a {
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .more-link {
+.wp-block-a8c-blog-posts .more-link {
 	display: block;
 	color: inherit;
 	margin-top: var(--global--spacing-unit);
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link:after {
 	content: "\02192";
 	display: inline-block;
 	margin-left: 0.5em;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:hover, .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:active {
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
 	color: var(--global--color-primary-hover);
 	text-decoration: none;
 }
 
-.has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:hover,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:hover,
-[style*="background-color"] .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:active,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:active,
-[style*="background-color"] .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:active {
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta,
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links {
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .cat-links {
 	color: var(--global--color-foreground-light);
 	font-size: var(--global--font-size-sm);
 }
 
-.has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta,
-[style*="background-color"] .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links,
+.wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links {
+.wp-block-a8c-blog-posts .cat-links {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: var(--global--spacing-unit);
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links .published + .updated {
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a,
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a {
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
 	color: currentColor;
 	text-decoration: underline;
 }
 
-.editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:hover, .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:active,
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:hover,
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:active {
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
 	color: var(--global--color-primary-hover);
 	text-decoration: none;
 }
 
-.has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:hover,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:hover,
-[style*="background-color"] .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:active,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:active,
-[style*="background-color"] .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
 [class*="background-color"]:not(.has-background-background-color)
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:hover,
 [style*="background-color"]
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
 [class*="background-color"]:not(.has-background-background-color)
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:active,
+.wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
-.editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:active {
+.wp-block-a8c-blog-posts .cat-links a:active {
 	color: currentColor;
 }
 
@@ -598,7 +598,7 @@ object {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-button .wp-block-button__link {
+.wp-block-button .wp-block-button__link {
 	color: var(--button--color-text);
 	font-weight: var(--button--font-weight);
 	font-family: var(--button--font-family);
@@ -609,27 +609,27 @@ object {
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
-.editor-styles-wrapper .wp-block-button .wp-block-button__link:hover, .editor-styles-wrapper .wp-block-button .wp-block-button__link:focus, .editor-styles-wrapper .wp-block-button .wp-block-button__link.has-focus {
+.wp-block-button .wp-block-button__link:hover, .wp-block-button .wp-block-button__link:focus, .wp-block-button .wp-block-button__link.has-focus {
 	color: var(--button--color-text-hover);
 	background-color: var(--button--color-background-hover);
 }
 
-.editor-styles-wrapper .wp-block-button.is-style-outline .wp-block-button__link {
+.wp-block-button.is-style-outline .wp-block-button__link {
 	color: var(--button--color-background);
 	background: transparent;
 	border: 2px solid currentcolor;
 }
 
-.editor-styles-wrapper .wp-block-button.is-style-outline .wp-block-button__link:hover, .editor-styles-wrapper .wp-block-button.is-style-outline .wp-block-button__link:focus, .editor-styles-wrapper .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+.wp-block-button.is-style-outline .wp-block-button__link:hover, .wp-block-button.is-style-outline .wp-block-button__link:focus, .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
 	color: var(--button--color-background-hover);
 }
 
-.editor-styles-wrapper .wp-block-button.is-style-squared .wp-block-button__link {
+.wp-block-button.is-style-squared .wp-block-button__link {
 	border-radius: 0;
 }
 
-.editor-styles-wrapper .wp-block-cover,
-.editor-styles-wrapper .wp-block-cover-image {
+.wp-block-cover,
+.wp-block-cover-image {
 	background-color: var(--cover--color-background);
 	color: var(--cover--color-foreground);
 	min-height: var(--cover--height);
@@ -637,41 +637,41 @@ object {
 	margin-bottom: inherit;
 }
 
-.editor-styles-wrapper .wp-block-cover .wp-block-cover__inner-container,
-.editor-styles-wrapper .wp-block-cover .wp-block-cover-image-text,
-.editor-styles-wrapper .wp-block-cover .wp-block-cover-text,
-.editor-styles-wrapper .wp-block-cover .block-editor-block-list__block,
-.editor-styles-wrapper .wp-block-cover-image .wp-block-cover__inner-container,
-.editor-styles-wrapper .wp-block-cover-image .wp-block-cover-image-text,
-.editor-styles-wrapper .wp-block-cover-image .wp-block-cover-text,
-.editor-styles-wrapper .wp-block-cover-image .block-editor-block-list__block {
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-cover .wp-block-cover__inner-container a,
-.editor-styles-wrapper .wp-block-cover .wp-block-cover-image-text a,
-.editor-styles-wrapper .wp-block-cover .wp-block-cover-text a,
-.editor-styles-wrapper .wp-block-cover .block-editor-block-list__block a,
-.editor-styles-wrapper .wp-block-cover-image .wp-block-cover__inner-container a,
-.editor-styles-wrapper .wp-block-cover-image .wp-block-cover-image-text a,
-.editor-styles-wrapper .wp-block-cover-image .wp-block-cover-text a,
-.editor-styles-wrapper .wp-block-cover-image .block-editor-block-list__block a {
+.wp-block-cover .wp-block-cover__inner-container a,
+.wp-block-cover .wp-block-cover-image-text a,
+.wp-block-cover .wp-block-cover-text a,
+.wp-block-cover .block-editor-block-list__block a,
+.wp-block-cover-image .wp-block-cover__inner-container a,
+.wp-block-cover-image .wp-block-cover-image-text a,
+.wp-block-cover-image .wp-block-cover-text a,
+.wp-block-cover-image .block-editor-block-list__block a {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.editor-styles-wrapper .wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.editor-styles-wrapper .wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.editor-styles-wrapper .wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.editor-styles-wrapper .wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.editor-styles-wrapper .wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.editor-styles-wrapper .wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.editor-styles-wrapper .wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
+.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
+.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
+.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
+.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
+.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
 	color: var(--cover--color-foreground);
 }
 
-.editor-styles-wrapper .wp-block-cover h2,
-.editor-styles-wrapper .wp-block-cover-image h2 {
+.wp-block-cover h2,
+.wp-block-cover-image h2 {
 	font-size: var(--heading--font-size-h2);
 	letter-spacing: var(--heading--letter-spacing-h2);
 	line-height: var(--heading--line-height);
@@ -680,241 +680,241 @@ object {
 	text-align: inherit;
 }
 
-.editor-styles-wrapper .wp-block-cover h2.has-text-align-left,
-.editor-styles-wrapper .wp-block-cover-image h2.has-text-align-left {
+.wp-block-cover h2.has-text-align-left,
+.wp-block-cover-image h2.has-text-align-left {
 	text-align: left;
 }
 
-.editor-styles-wrapper .wp-block-cover h2.has-text-align-center,
-.editor-styles-wrapper .wp-block-cover-image h2.has-text-align-center {
+.wp-block-cover h2.has-text-align-center,
+.wp-block-cover-image h2.has-text-align-center {
 	text-align: center;
 }
 
-.editor-styles-wrapper .wp-block-cover h2.has-text-align-right,
-.editor-styles-wrapper .wp-block-cover-image h2.has-text-align-right {
+.wp-block-cover h2.has-text-align-right,
+.wp-block-cover-image h2.has-text-align-right {
 	text-align: right;
 }
 
-.editor-styles-wrapper .wp-block-gallery figcaption {
+.wp-block-gallery figcaption {
 	margin-bottom: 0;
 }
 
-.editor-styles-wrapper .wp-block-group.has-background {
+.wp-block-group.has-background {
 	padding: calc( 0.666 * var(--global--spacing-vertical));
 }
 
 @media only screen and (min-width: 560px) {
-	.editor-styles-wrapper .wp-block-group.has-background {
+	.wp-block-group.has-background {
 		padding: var(--global--spacing-vertical);
 	}
 }
 
-.editor-styles-wrapper .wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
+.wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
 	margin: 0;
 	width: 100%;
 }
 
-.editor-styles-wrapper .wp-block-heading h1, .editor-styles-wrapper h1, .editor-styles-wrapper .h1,
-.editor-styles-wrapper .wp-block-heading h2, .editor-styles-wrapper h2, .editor-styles-wrapper .h2,
-.editor-styles-wrapper .wp-block-heading h3, .editor-styles-wrapper h3, .editor-styles-wrapper .h3,
-.editor-styles-wrapper .wp-block-heading h4, .editor-styles-wrapper h4, .editor-styles-wrapper .h4,
-.editor-styles-wrapper .wp-block-heading h5, .editor-styles-wrapper h5, .editor-styles-wrapper .h5,
-.editor-styles-wrapper .wp-block-heading h6, .editor-styles-wrapper h6, .editor-styles-wrapper .h6 {
+.wp-block-heading h1, h1, .h1,
+.wp-block-heading h2, h2, .h2,
+.wp-block-heading h3, h3, .h3,
+.wp-block-heading h4, h4, .h4,
+.wp-block-heading h5, h5, .h5,
+.wp-block-heading h6, h6, .h6 {
 	clear: both;
 	font-family: var(--heading--font-family);
 	font-weight: var(--heading--font-weight);
 }
 
-.editor-styles-wrapper .wp-block-heading h1 strong, .editor-styles-wrapper h1 strong, .editor-styles-wrapper .h1 strong,
-.editor-styles-wrapper .wp-block-heading h2 strong, .editor-styles-wrapper h2 strong, .editor-styles-wrapper .h2 strong,
-.editor-styles-wrapper .wp-block-heading h3 strong, .editor-styles-wrapper h3 strong, .editor-styles-wrapper .h3 strong,
-.editor-styles-wrapper .wp-block-heading h4 strong, .editor-styles-wrapper h4 strong, .editor-styles-wrapper .h4 strong,
-.editor-styles-wrapper .wp-block-heading h5 strong, .editor-styles-wrapper h5 strong, .editor-styles-wrapper .h5 strong,
-.editor-styles-wrapper .wp-block-heading h6 strong, .editor-styles-wrapper h6 strong, .editor-styles-wrapper .h6 strong {
+.wp-block-heading h1 strong, h1 strong, .h1 strong,
+.wp-block-heading h2 strong, h2 strong, .h2 strong,
+.wp-block-heading h3 strong, h3 strong, .h3 strong,
+.wp-block-heading h4 strong, h4 strong, .h4 strong,
+.wp-block-heading h5 strong, h5 strong, .h5 strong,
+.wp-block-heading h6 strong, h6 strong, .h6 strong {
 	font-weight: var(--heading--font-weight-strong);
 }
 
-.editor-styles-wrapper .wp-block-heading h1, .editor-styles-wrapper h1, .editor-styles-wrapper .h1 {
+.wp-block-heading h1, h1, .h1 {
 	font-size: var(--heading--font-size-h1);
 	letter-spacing: var(--heading--letter-spacing-h1);
 	line-height: var(--heading--line-height);
 }
 
-.editor-styles-wrapper .wp-block-heading h2, .editor-styles-wrapper h2, .editor-styles-wrapper .h2 {
+.wp-block-heading h2, h2, .h2 {
 	font-size: var(--heading--font-size-h2);
 	letter-spacing: var(--heading--letter-spacing-h2);
 	line-height: var(--heading--line-height);
 }
 
-.editor-styles-wrapper .wp-block-heading h3, .editor-styles-wrapper h3, .editor-styles-wrapper .h3 {
+.wp-block-heading h3, h3, .h3 {
 	font-size: var(--heading--font-size-h3);
 	letter-spacing: var(--heading--letter-spacing-h3);
 	line-height: var(--heading--line-height);
 }
 
-.editor-styles-wrapper .wp-block-heading h4, .editor-styles-wrapper h4, .editor-styles-wrapper .h4 {
+.wp-block-heading h4, h4, .h4 {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
 	line-height: var(--heading--line-height);
 }
 
-.editor-styles-wrapper .wp-block-heading h5, .editor-styles-wrapper h5, .editor-styles-wrapper .h5 {
+.wp-block-heading h5, h5, .h5 {
 	font-size: var(--heading--font-size-h5);
 	letter-spacing: var(--heading--letter-spacing-h5);
 	line-height: var(--global--line-height-body);
 }
 
-.editor-styles-wrapper .wp-block-heading h6, .editor-styles-wrapper h6, .editor-styles-wrapper .h6 {
+.wp-block-heading h6, h6, .h6 {
 	font-size: var(--heading--font-size-h6);
 	letter-spacing: var(--heading--letter-spacing-h6);
 	line-height: var(--global--line-height-body);
 }
 
 /* Center image block by default in the editor */
-.editor-styles-wrapper .wp-block-image > div {
+.wp-block-image > div {
 	text-align: center;
 }
 
-.editor-styles-wrapper [data-type="core/image"] .block-editor-block-list__block-edit figure.is-resized {
+[data-type="core/image"] .block-editor-block-list__block-edit figure.is-resized {
 	margin: 0 auto;
 }
 
-.editor-styles-wrapper .wp-block-latest-comments {
+.wp-block-latest-comments {
 	margin-left: 0;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts {
+.wp-block-latest-posts {
 	padding-left: 0;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts:not(.is-grid) > li {
+.wp-block-latest-posts:not(.is-grid) > li {
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-.editor-styles-wrapper .wp-block-latest-posts:not(.is-grid) > li:first-child {
+.wp-block-latest-posts:not(.is-grid) > li:first-child {
 	margin-top: 0;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts:not(.is-grid) > li:last-child {
+.wp-block-latest-posts:not(.is-grid) > li:last-child {
 	margin-bottom: 0;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts.is-grid > li {
+.wp-block-latest-posts.is-grid > li {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-.editor-styles-wrapper .wp-block-latest-posts.is-grid > li:last-child {
+.wp-block-latest-posts.is-grid > li:last-child {
 	margin-bottom: 0;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts > li > * {
+.wp-block-latest-posts > li > * {
 	margin-top: calc(0.5 * var(--global--spacing-vertical));
 	margin-bottom: calc(0.5 * var(--global--spacing-vertical));
 }
 
-.editor-styles-wrapper .wp-block-latest-posts > li > *:first-child {
+.wp-block-latest-posts > li > *:first-child {
 	margin-top: 0;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts > li > *:last-child {
+.wp-block-latest-posts > li > *:last-child {
 	margin-bottom: 0;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts > li > a {
+.wp-block-latest-posts > li > a {
 	font-family: var(--latest-posts--title-font-family);
 	font-size: var(--latest-posts--title-font-size);
 	font-weight: var(--heading--font-weight);
 	line-height: var(--global--line-height-heading);
 }
 
-.editor-styles-wrapper .wp-block-latest-posts .wp-block-latest-posts__post-date {
+.wp-block-latest-posts .wp-block-latest-posts__post-date {
 	color: var(--global--color-foreground-light);
 	font-size: var(--global--font-size-xs);
 	line-height: var(--global--line-height-body);
 }
 
-[class*="inner-container"] .editor-styles-wrapper .wp-block-latest-posts .wp-block-latest-posts__post-date,
-.has-background .editor-styles-wrapper .wp-block-latest-posts .wp-block-latest-posts__post-date {
+[class*="inner-container"] .wp-block-latest-posts .wp-block-latest-posts__post-date,
+.has-background .wp-block-latest-posts .wp-block-latest-posts__post-date {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts .wp-block-latest-posts__post-excerpt,
-.editor-styles-wrapper .wp-block-latest-posts .wp-block-latest-posts__post-full-content {
+.wp-block-latest-posts .wp-block-latest-posts__post-excerpt,
+.wp-block-latest-posts .wp-block-latest-posts__post-full-content {
 	font-family: var(--latest-posts--description-font-family);
 	font-size: var(--latest-posts--description-font-size);
 	line-height: var(--global--line-height-body);
 }
 
-.editor-styles-wrapper .gallery-item {
+.gallery-item {
 	display: inline-block;
 	text-align: center;
 	vertical-align: top;
 	width: 100%;
 }
 
-.gallery-columns-2 .editor-styles-wrapper .gallery-item {
+.gallery-columns-2 .gallery-item {
 	max-width: 50%;
 }
 
-.gallery-columns-3 .editor-styles-wrapper .gallery-item {
+.gallery-columns-3 .gallery-item {
 	max-width: 33.33%;
 }
 
-.gallery-columns-4 .editor-styles-wrapper .gallery-item {
+.gallery-columns-4 .gallery-item {
 	max-width: 25%;
 }
 
-.gallery-columns-5 .editor-styles-wrapper .gallery-item {
+.gallery-columns-5 .gallery-item {
 	max-width: 20%;
 }
 
-.gallery-columns-6 .editor-styles-wrapper .gallery-item {
+.gallery-columns-6 .gallery-item {
 	max-width: 16.66%;
 }
 
-.gallery-columns-7 .editor-styles-wrapper .gallery-item {
+.gallery-columns-7 .gallery-item {
 	max-width: 14.28%;
 }
 
-.gallery-columns-8 .editor-styles-wrapper .gallery-item {
+.gallery-columns-8 .gallery-item {
 	max-width: 12.5%;
 }
 
-.gallery-columns-9 .editor-styles-wrapper .gallery-item {
+.gallery-columns-9 .gallery-item {
 	max-width: 11.11%;
 }
 
-.editor-styles-wrapper .gallery-caption {
+.gallery-caption {
 	display: block;
 }
 
-.editor-styles-wrapper ul,
-.editor-styles-wrapper ol {
+ul,
+ol {
 	font-family: var(--list--font-family);
 	margin: var(--global--spacing-vertical) 0;
 	padding-left: calc( 2 * var(--global--spacing-horizontal));
 }
 
-.editor-styles-wrapper ul.aligncenter,
-.editor-styles-wrapper ol.aligncenter {
+ul.aligncenter,
+ol.aligncenter {
 	list-style-position: inside;
 	padding: 0;
 }
 
-.editor-styles-wrapper ul.alignright,
-.editor-styles-wrapper ol.alignright {
+ul.alignright,
+ol.alignright {
 	list-style-position: inside;
 	text-align: right;
 	padding: 0;
 }
 
-.editor-styles-wrapper li > ul,
-.editor-styles-wrapper li > ol {
+li > ul,
+li > ol {
 	margin: 0;
 }
 
-.editor-styles-wrapper dt {
+dt {
 	font-family: var(--definition-term--font-family);
 	font-weight: bold;
 }
@@ -935,15 +935,15 @@ object {
 	color: currentColor;
 }
 
-.editor-styles-wrapper p.has-background {
+p.has-background {
 	padding: var(--global--spacing-unit);
 }
 
-.editor-styles-wrapper p.has-background:not(.has-background-background-color) a {
+p.has-background:not(.has-background-background-color) a {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .a8c-posts-list {
+.a8c-posts-list {
 	padding-left: 0;
 }
 
@@ -1015,119 +1015,119 @@ object {
 	margin-right: auto;
 }
 
-.editor-styles-wrapper .wp-block-quote {
+.wp-block-quote {
 	border-left-color: var(--quote--border-color);
 	margin: var(--global--spacing-vertical) 0;
 	padding-left: var(--global--spacing-horizontal);
 }
 
-.editor-styles-wrapper .wp-block-quote p {
+.wp-block-quote p {
 	font-family: var(--quote--font-family);
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
 	line-height: var(--global--line-height-h4);
 }
 
-.editor-styles-wrapper .wp-block-quote.is-large, .editor-styles-wrapper .wp-block-quote.is-style-large {
+.wp-block-quote.is-large, .wp-block-quote.is-style-large {
 	border: none;
 	padding: 0;
 }
 
-.editor-styles-wrapper .wp-block-quote.is-large p, .editor-styles-wrapper .wp-block-quote.is-style-large p {
+.wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
 	font-family: var(--quote--font-family);
 	font-size: var(--heading--font-size-h3);
 	letter-spacing: var(--heading--letter-spacing-h3);
 	line-height: var(--global--line-height-h3);
 }
 
-.has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-quote,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-quote,
-[style*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-quote,
-.wp-block-cover[style*="background-image"] .editor-styles-wrapper .wp-block-quote {
+.has-background:not(.has-background-background-color) .wp-block-quote,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-quote,
+[style*="background-color"]:not(.has-background-background-color) .wp-block-quote,
+.wp-block-cover[style*="background-image"] .wp-block-quote {
 	border-color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-quote .wp-block-quote__citation {
+.wp-block-quote .wp-block-quote__citation {
 	color: var(--global--color-foreground-light);
 	font-size: var(--global--font-size-sm);
 }
 
-.has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-quote .wp-block-quote__citation,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-quote .wp-block-quote__citation,
-[style*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-quote .wp-block-quote__citation,
-.wp-block-cover[style*="background-image"] .editor-styles-wrapper .wp-block-quote .wp-block-quote__citation {
+.has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+[style*="background-color"]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+.wp-block-cover[style*="background-image"] .wp-block-quote .wp-block-quote__citation {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-separator,
-.editor-styles-wrapper hr {
+.wp-block-separator,
+hr {
 	border-bottom: var(--separator--height) solid var(--separator--border-color);
 	clear: both;
 }
 
-.editor-styles-wrapper .wp-block-separator[style*="text-align:right"], .editor-styles-wrapper .wp-block-separator[style*="text-align: right"],
-.editor-styles-wrapper hr[style*="text-align:right"],
-.editor-styles-wrapper hr[style*="text-align: right"] {
+.wp-block-separator[style*="text-align:right"], .wp-block-separator[style*="text-align: right"],
+hr[style*="text-align:right"],
+hr[style*="text-align: right"] {
 	border-right-color: var(--separator--border-color);
 }
 
-.editor-styles-wrapper .wp-block-separator.is-style-wide,
-.editor-styles-wrapper hr.is-style-wide {
+.wp-block-separator.is-style-wide,
+hr.is-style-wide {
 	border-bottom-width: var(--separator--height);
 }
 
-.editor-styles-wrapper .wp-block-separator.is-style-dots,
-.editor-styles-wrapper hr.is-style-dots {
+.wp-block-separator.is-style-dots,
+hr.is-style-dots {
 	border-bottom: none;
 }
 
-.editor-styles-wrapper .wp-block-separator.is-style-dots.has-background, .editor-styles-wrapper .wp-block-separator.is-style-dots.has-text-color,
-.editor-styles-wrapper hr.is-style-dots.has-background,
-.editor-styles-wrapper hr.is-style-dots.has-text-color {
+.wp-block-separator.is-style-dots.has-background, .wp-block-separator.is-style-dots.has-text-color,
+hr.is-style-dots.has-background,
+hr.is-style-dots.has-text-color {
 	background-color: transparent !important;
 }
 
-.editor-styles-wrapper .wp-block-separator.is-style-dots.has-background:before, .editor-styles-wrapper .wp-block-separator.is-style-dots.has-text-color:before,
-.editor-styles-wrapper hr.is-style-dots.has-background:before,
-.editor-styles-wrapper hr.is-style-dots.has-text-color:before {
+.wp-block-separator.is-style-dots.has-background:before, .wp-block-separator.is-style-dots.has-text-color:before,
+hr.is-style-dots.has-background:before,
+hr.is-style-dots.has-text-color:before {
 	color: currentColor !important;
 }
 
-.editor-styles-wrapper .wp-block-separator.is-style-dots:before,
-.editor-styles-wrapper hr.is-style-dots:before {
+.wp-block-separator.is-style-dots:before,
+hr.is-style-dots:before {
 	color: var(--separator--border-color);
 }
 
-.has-background:not(.has-background-background-color) .editor-styles-wrapper .wp-block-separator,
-[class*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-separator,
-[style*="background-color"]:not(.has-background-background-color) .editor-styles-wrapper .wp-block-separator,
-.wp-block-cover[style*="background-image"] .editor-styles-wrapper .wp-block-separator, .has-background:not(.has-background-background-color)
-.editor-styles-wrapper hr,
+.has-background:not(.has-background-background-color) .wp-block-separator,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-separator,
+[style*="background-color"]:not(.has-background-background-color) .wp-block-separator,
+.wp-block-cover[style*="background-image"] .wp-block-separator, .has-background:not(.has-background-background-color)
+hr,
 [class*="background-color"]:not(.has-background-background-color)
-.editor-styles-wrapper hr,
+hr,
 [style*="background-color"]:not(.has-background-background-color)
-.editor-styles-wrapper hr,
+hr,
 .wp-block-cover[style*="background-image"]
-.editor-styles-wrapper hr {
+hr {
 	border-color: currentColor;
 }
 
-.editor-styles-wrapper table th,
-.editor-styles-wrapper .wp-block-table th {
+table th,
+.wp-block-table th {
 	font-family: var(--heading--font-family);
 }
 
-.editor-styles-wrapper table td,
-.editor-styles-wrapper table th,
-.editor-styles-wrapper .wp-block-table td,
-.editor-styles-wrapper .wp-block-table th {
+table td,
+table th,
+.wp-block-table td,
+.wp-block-table th {
 	padding: calc( 0.5 * var(--global--spacing-unit));
 }
 
 /**
- * Editor Post Title
- * - Needs a special styles
- */
+* Editor Post Title
+* - Needs a special styles
+*/
 .editor-post-title__block .editor-post-title__input {
 	color: var(--global--color-foreground);
 	font-family: var(--heading--font-family);
@@ -1137,142 +1137,139 @@ object {
 	line-height: var(--heading--line-height);
 }
 
-.editor-styles-wrapper {
-	/**
-	 * Spacing Overrides
-	 */
-}
-
-.editor-styles-wrapper .has-primary-color[class] {
+.has-primary-color[class] {
 	color: var(--global--color-primary) !important;
 }
 
-.editor-styles-wrapper .has-secondary-color[class] {
+.has-secondary-color[class] {
 	color: var(--global--color-secondary) !important;
 }
 
-.editor-styles-wrapper .has-foreground-color[class] {
+.has-foreground-color[class] {
 	color: var(--global--color-foreground) !important;
 }
 
-.editor-styles-wrapper .has-foreground-light-color[class] {
+.has-foreground-light-color[class] {
 	color: var(--global--color-foreground-light) !important;
 }
 
-.editor-styles-wrapper .has-foreground-dark-color[class] {
+.has-foreground-dark-color[class] {
 	color: var(--global--color-foreground-dark) !important;
 }
 
-.editor-styles-wrapper .has-background-light-color[class] {
+.has-background-light-color[class] {
 	color: var(--global--color-background-light) !important;
 }
 
-.editor-styles-wrapper .has-background-dark-color[class] {
+.has-background-dark-color[class] {
 	color: var(--global--color-background-dark) !important;
 }
 
-.editor-styles-wrapper .has-background-color[class] {
+.has-background-color[class] {
 	color: var(--global--color-background) !important;
 }
 
-.editor-styles-wrapper .has-background:not(.has-background-background-color) a,
-.editor-styles-wrapper .has-background p, .editor-styles-wrapper .has-background h1, .editor-styles-wrapper .has-background h2, .editor-styles-wrapper .has-background h3, .editor-styles-wrapper .has-background h4, .editor-styles-wrapper .has-background h5, .editor-styles-wrapper .has-background h6 {
+.has-background:not(.has-background-background-color) a,
+.has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .has-primary-background-color[class] {
+.has-primary-background-color[class] {
 	background-color: var(--global--color-primary) !important;
 	color: var(--global--color-background);
 }
 
-.editor-styles-wrapper .has-primary-background-color[class] {
+.has-primary-background-color[class] {
 	background-color: var(--global--color-primary) !important;
 	color: var(--global--color-background);
 }
 
-.editor-styles-wrapper .has-secondary-background-color[class] {
+.has-secondary-background-color[class] {
 	background-color: var(--global--color-secondary) !important;
 	color: var(--global--color-background);
 }
 
-.editor-styles-wrapper .has-foreground-background-color[class] {
+.has-foreground-background-color[class] {
 	background-color: var(--global--color-foreground) !important;
 	color: var(--global--color-background);
 }
 
-.editor-styles-wrapper .has-foreground-light-background-color[class] {
+.has-foreground-light-background-color[class] {
 	background-color: var(--global--color-foreground-light) !important;
 	color: var(--global--color-background);
 }
 
-.editor-styles-wrapper .has-foreground-dark-background-color[class] {
+.has-foreground-dark-background-color[class] {
 	background-color: var(--global--color-foreground-dark) !important;
 	color: var(--global--color-background);
 }
 
-.editor-styles-wrapper .has-background-light-background-color[class] {
+.has-background-light-background-color[class] {
 	background-color: var(--global--color-background-light) !important;
 	color: var(--global--color-foreground);
 }
 
-.editor-styles-wrapper .has-background-dark-background-color[class] {
+.has-background-dark-background-color[class] {
 	background-color: var(--global--color-background-dark) !important;
 	color: var(--global--color-foreground);
 }
 
-.editor-styles-wrapper .has-background-background-color[class] {
+.has-background-background-color[class] {
 	background-color: var(--global--color-background) !important;
 	color: var(--global--color-foreground);
 }
 
-.editor-styles-wrapper .has-white-background-color[class] {
+.has-white-background-color[class] {
 	background-color: var(--global--color-white) !important;
 	color: var(--global--color-secondary);
 }
 
-.editor-styles-wrapper .has-black-background-color[class] {
+.has-black-background-color[class] {
 	background-color: var(--global--color-black) !important;
 	color: var(--global--color-primary);
 }
 
-.editor-styles-wrapper .is-small-text,
-.editor-styles-wrapper .has-small-font-size {
+.is-small-text,
+.has-small-font-size {
 	font-size: var(--global--font-size-sm);
 }
 
-.editor-styles-wrapper .is-regular-text,
-.editor-styles-wrapper .has-regular-font-size,
-.editor-styles-wrapper .has-normal-font-size,
-.editor-styles-wrapper .has-medium-font-size {
+.is-regular-text,
+.has-regular-font-size,
+.has-normal-font-size,
+.has-medium-font-size {
 	font-size: var(--global--font-size-md);
 }
 
-.editor-styles-wrapper .is-large-text,
-.editor-styles-wrapper .has-large-font-size {
+.is-large-text,
+.has-large-font-size {
 	font-size: var(--global--font-size-lg);
 	line-height: var(--global--line-height-heading);
 }
 
-.editor-styles-wrapper .is-larger-text,
-.editor-styles-wrapper .has-larger-font-size,
-.editor-styles-wrapper .has-huge-font-size {
+.is-larger-text,
+.has-larger-font-size,
+.has-huge-font-size {
 	font-size: var(--global--font-size-xl);
 	line-height: var(--global--line-height-heading);
 }
 
-.editor-styles-wrapper .has-drop-cap:not(:focus)::first-letter {
+.has-drop-cap:not(:focus)::first-letter {
 	font-family: var(--heading--font-family);
 	font-size: calc(2 * var(--heading--font-size-h1));
 	font-weight: var(--heading--font-weight);
 }
 
-.editor-styles-wrapper [data-block] {
+/**
+ * Spacing Overrides
+ */
+[data-block] {
 	margin-top: calc( 0.666 * var(--global--spacing-vertical));
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
 @media only screen and (min-width: 560px) {
-	.editor-styles-wrapper [data-block] {
+	[data-block] {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
 	}

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -947,7 +947,7 @@ p.has-background:not(.has-background-background-color) a {
 	padding-left: 0;
 }
 
-.editor-styles-wrapper .wp-block-pullquote {
+.wp-block-pullquote {
 	padding: calc( 3 * var(--global--spacing-unit)) 0;
 	margin-left: 0;
 	margin-right: 0;
@@ -959,58 +959,58 @@ p.has-background:not(.has-background-background-color) a {
 	color: var(--pullquote--color-foreground);
 }
 
-.editor-styles-wrapper .wp-block-pullquote blockquote {
+.wp-block-pullquote blockquote {
 	padding-left: 0;
 }
 
-.editor-styles-wrapper .wp-block-pullquote p {
+.wp-block-pullquote p {
 	font-family: var(--pullquote--font-family);
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
 	line-height: var(--heading--line-height);
 }
 
-.editor-styles-wrapper .wp-block-pullquote a {
+.wp-block-pullquote a {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-pullquote .wp-block-pullquote__citation,
-.editor-styles-wrapper .wp-block-pullquote cite,
-.editor-styles-wrapper .wp-block-pullquote footer {
+.wp-block-pullquote .wp-block-pullquote__citation,
+.wp-block-pullquote cite,
+.wp-block-pullquote footer {
 	color: var(--global--color-foreground-light);
 	font-size: var(--global--font-size-sm);
 }
 
-.editor-styles-wrapper .wp-block-pullquote:not(.is-style-solid-color) {
+.wp-block-pullquote:not(.is-style-solid-color) {
 	background: none;
 }
 
-.editor-styles-wrapper .wp-block-pullquote.is-style-solid-color {
+.wp-block-pullquote.is-style-solid-color {
 	background-color: var(--pullquote--color-foreground);
 	color: var(--pullquote--color-background);
 }
 
-.editor-styles-wrapper .wp-block-pullquote.is-style-solid-color.alignleft blockquote,
-.editor-styles-wrapper .wp-block-pullquote.is-style-solid-color.alignright blockquote {
+.wp-block-pullquote.is-style-solid-color.alignleft blockquote,
+.wp-block-pullquote.is-style-solid-color.alignright blockquote {
 	padding-left: var(--global--spacing-unit);
 	padding-right: var(--global--spacing-unit);
 	max-width: inherit;
 }
 
-.editor-styles-wrapper .wp-block-pullquote.is-style-solid-color blockquote {
+.wp-block-pullquote.is-style-solid-color blockquote {
 	padding-left: 0;
 }
 
-.editor-styles-wrapper .wp-block-pullquote.is-style-solid-color .wp-block-pullquote__citation,
-.editor-styles-wrapper .wp-block-pullquote.is-style-solid-color cite,
-.editor-styles-wrapper .wp-block-pullquote.is-style-solid-color footer {
+.wp-block-pullquote.is-style-solid-color .wp-block-pullquote__citation,
+.wp-block-pullquote.is-style-solid-color cite,
+.wp-block-pullquote.is-style-solid-color footer {
 	color: currentColor;
 }
 
-.editor-styles-wrapper .wp-block-pullquote.alignwide > p,
-.editor-styles-wrapper .wp-block-pullquote.alignfull > p,
-.editor-styles-wrapper .wp-block-pullquote.alignwide blockquote,
-.editor-styles-wrapper .wp-block-pullquote.alignfull blockquote {
+.wp-block-pullquote.alignwide > p,
+.wp-block-pullquote.alignfull > p,
+.wp-block-pullquote.alignwide blockquote,
+.wp-block-pullquote.alignfull blockquote {
 	margin-left: auto;
 	margin-right: auto;
 }

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -13,7 +13,7 @@
 /**
  * WooCommerce Variables
  */
-.editor-styles-wrapper {
+body {
 	/* Globals */
 	/* Font Family */
 	--global--font-primary: sans-serif;

--- a/varya/assets/sass/abstracts/_mixins.scss
+++ b/varya/assets/sass/abstracts/_mixins.scss
@@ -8,7 +8,7 @@
 	}
 
 	@if editor == $view {
-		.editor-styles-wrapper {
+		body {
 			@content;
 		}
 	}

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -1,4 +1,4 @@
-#wpwrap .editor-styles-wrapper {
+body {
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);
@@ -15,7 +15,7 @@
 }
 
 // Links styles
-.editor-styles-wrapper a {
+a {
 	color: var(--global--color-primary);
 
 	&:hover {
@@ -23,7 +23,7 @@
 	}
 }
 
-.editor-styles-wrapper button,
-.editor-styles-wrapper a {
+button,
+a {
 	cursor: pointer;
 }

--- a/varya/assets/sass/blocks/blog-posts/_editor.scss
+++ b/varya/assets/sass/blocks/blog-posts/_editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-a8c-blog-posts {
+.wp-block-a8c-blog-posts {
 	&.image-aligntop {
 		.post-thumbnail {
 			margin-bottom: calc(0.5 * var(--global--spacing-vertical));

--- a/varya/assets/sass/blocks/button/_editor.scss
+++ b/varya/assets/sass/blocks/button/_editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-button {
+.wp-block-button {
 
 	// Default Style
 	.wp-block-button__link {

--- a/varya/assets/sass/blocks/cover/_editor.scss
+++ b/varya/assets/sass/blocks/cover/_editor.scss
@@ -1,54 +1,52 @@
-.editor-styles-wrapper {
-	.wp-block-cover,
-	.wp-block-cover-image {
+.wp-block-cover,
+.wp-block-cover-image {
 
-		background-color: var(--cover--color-background);
-		color: var(--cover--color-foreground);
-		min-height: var(--cover--height);
-		margin-top: inherit;
-		margin-bottom: inherit;
+	background-color: var(--cover--color-background);
+	color: var(--cover--color-foreground);
+	min-height: var(--cover--height);
+	margin-top: inherit;
+	margin-bottom: inherit;
 
+	.wp-block-cover__inner-container,
+	.wp-block-cover-image-text,
+	.wp-block-cover-text,
+	.block-editor-block-list__block {
+		color: currentColor; // uses text color specified with background-color options in /blocks/utilities/_style.scss
+
+		a {
+			color: currentColor;
+		}
+	}
+
+	// Default & custom background-color
+	&:not([class*='background-color']){
 		.wp-block-cover__inner-container,
 		.wp-block-cover-image-text,
 		.wp-block-cover-text,
 		.block-editor-block-list__block {
-			color: currentColor; // uses text color specified with background-color options in /blocks/utilities/_style.scss
+			color: var(--cover--color-foreground);
+		}
+	}
 
-			a {
-				color: currentColor;
-			}
+	// Treating H2 separately to account for legacy /core styles
+	h2 {
+		font-size: var(--heading--font-size-h2);
+		letter-spacing: var(--heading--letter-spacing-h2);
+		line-height: var(--heading--line-height);
+		padding: 0;
+		max-width: inherit; // undo opinionated styles
+		text-align: inherit;
+
+		&.has-text-align-left {
+			text-align: left;
 		}
 
-		// Default & custom background-color
-		&:not([class*='background-color']){
-			.wp-block-cover__inner-container,
-			.wp-block-cover-image-text,
-			.wp-block-cover-text,
-			.block-editor-block-list__block {
-				color: var(--cover--color-foreground);
-			}
+		&.has-text-align-center {
+			text-align: center;
 		}
 
-		// Treating H2 separately to account for legacy /core styles
-		h2 {
-			font-size: var(--heading--font-size-h2);
-			letter-spacing: var(--heading--letter-spacing-h2);
-			line-height: var(--heading--line-height);
-			padding: 0;
-			max-width: inherit; // undo opinionated styles
-			text-align: inherit;
-
-			&.has-text-align-left {
-				text-align: left;
-			}
-
-			&.has-text-align-center {
-				text-align: center;
-			}
-
-			&.has-text-align-right {
-				text-align: right;
-			}
+		&.has-text-align-right {
+			text-align: right;
 		}
 	}
 }

--- a/varya/assets/sass/blocks/gallery/_editor.scss
+++ b/varya/assets/sass/blocks/gallery/_editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-gallery {
+.wp-block-gallery {
 	figcaption {
 		margin-bottom: 0;
 	}

--- a/varya/assets/sass/blocks/group/_editor.scss
+++ b/varya/assets/sass/blocks/group/_editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-group {
+.wp-block-group {
 	&.has-background {
 		padding: calc( 0.666 * var(--global--spacing-vertical) );
 
@@ -8,7 +8,7 @@
 	}
 }
 
-.editor-styles-wrapper .wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
+.wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
 	margin: 0;
 	width: 100%;
 }

--- a/varya/assets/sass/blocks/heading/_editor.scss
+++ b/varya/assets/sass/blocks/heading/_editor.scss
@@ -1,53 +1,50 @@
-.editor-styles-wrapper {
+.wp-block-heading h1, h1, .h1,
+.wp-block-heading h2, h2, .h2,
+.wp-block-heading h3, h3, .h3,
+.wp-block-heading h4, h4, .h4,
+.wp-block-heading h5, h5, .h5,
+.wp-block-heading h6, h6, .h6 {
+	clear: both;
+	font-family: var(--heading--font-family);
+	font-weight: var(--heading--font-weight);
 
-	.wp-block-heading h1, h1, .h1,
-	.wp-block-heading h2, h2, .h2,
-	.wp-block-heading h3, h3, .h3,
-	.wp-block-heading h4, h4, .h4,
-	.wp-block-heading h5, h5, .h5,
-	.wp-block-heading h6, h6, .h6 {
-		clear: both;
-		font-family: var(--heading--font-family);
-		font-weight: var(--heading--font-weight);
-
-		strong {
-			font-weight: var(--heading--font-weight-strong);
-		}
+	strong {
+		font-weight: var(--heading--font-weight-strong);
 	}
+}
 
-	.wp-block-heading h1, h1, .h1 {
-		font-size: var(--heading--font-size-h1);
-		letter-spacing: var(--heading--letter-spacing-h1);
-		line-height: var(--heading--line-height);
-	}
+.wp-block-heading h1, h1, .h1 {
+	font-size: var(--heading--font-size-h1);
+	letter-spacing: var(--heading--letter-spacing-h1);
+	line-height: var(--heading--line-height);
+}
 
-	.wp-block-heading h2, h2, .h2 {
-		font-size: var(--heading--font-size-h2);
-		letter-spacing: var(--heading--letter-spacing-h2);
-		line-height: var(--heading--line-height);
-	}
+.wp-block-heading h2, h2, .h2 {
+	font-size: var(--heading--font-size-h2);
+	letter-spacing: var(--heading--letter-spacing-h2);
+	line-height: var(--heading--line-height);
+}
 
-	.wp-block-heading h3, h3, .h3 {
-		font-size: var(--heading--font-size-h3);
-		letter-spacing: var(--heading--letter-spacing-h3);
-		line-height: var(--heading--line-height);
-	}
+.wp-block-heading h3, h3, .h3 {
+	font-size: var(--heading--font-size-h3);
+	letter-spacing: var(--heading--letter-spacing-h3);
+	line-height: var(--heading--line-height);
+}
 
-	.wp-block-heading h4, h4, .h4 {
-		font-size: var(--heading--font-size-h4);
-		letter-spacing: var(--heading--letter-spacing-h4);
-		line-height: var(--heading--line-height);
-	}
+.wp-block-heading h4, h4, .h4 {
+	font-size: var(--heading--font-size-h4);
+	letter-spacing: var(--heading--letter-spacing-h4);
+	line-height: var(--heading--line-height);
+}
 
-	.wp-block-heading h5, h5, .h5 {
-		font-size: var(--heading--font-size-h5);
-		letter-spacing: var(--heading--letter-spacing-h5);
-		line-height: var(--global--line-height-body);
-	}
+.wp-block-heading h5, h5, .h5 {
+	font-size: var(--heading--font-size-h5);
+	letter-spacing: var(--heading--letter-spacing-h5);
+	line-height: var(--global--line-height-body);
+}
 
-	.wp-block-heading h6, h6, .h6 {
-		font-size: var(--heading--font-size-h6);
-		letter-spacing: var(--heading--letter-spacing-h6);
-		line-height: var(--global--line-height-body);
-	}
+.wp-block-heading h6, h6, .h6 {
+	font-size: var(--heading--font-size-h6);
+	letter-spacing: var(--heading--letter-spacing-h6);
+	line-height: var(--global--line-height-body);
 }

--- a/varya/assets/sass/blocks/image/_editor.scss
+++ b/varya/assets/sass/blocks/image/_editor.scss
@@ -1,9 +1,9 @@
 /* Center image block by default in the editor */
 
-.editor-styles-wrapper .wp-block-image > div {
+.wp-block-image > div {
 	text-align: center;
 }
 
-.editor-styles-wrapper [data-type="core/image"] .block-editor-block-list__block-edit figure.is-resized {
+[data-type="core/image"] .block-editor-block-list__block-edit figure.is-resized {
 	margin: 0 auto;
 }

--- a/varya/assets/sass/blocks/latest-comments/_editor.scss
+++ b/varya/assets/sass/blocks/latest-comments/_editor.scss
@@ -1,3 +1,3 @@
-.editor-styles-wrapper .wp-block-latest-comments {
+.wp-block-latest-comments {
 	margin-left: 0;
 }

--- a/varya/assets/sass/blocks/latest-posts/_editor.scss
+++ b/varya/assets/sass/blocks/latest-posts/_editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-latest-posts {
+.wp-block-latest-posts {
 	padding-left: 0;
 
 	// Vertical margins logic

--- a/varya/assets/sass/blocks/legacy/_editor.scss
+++ b/varya/assets/sass/blocks/legacy/_editor.scss
@@ -1,8 +1,8 @@
-.editor-styles-wrapper .gallery {
+.gallery {
 
 }
 
-.editor-styles-wrapper .gallery-item {
+.gallery-item {
 	display: inline-block;
 	text-align: center;
 	vertical-align: top;
@@ -41,6 +41,6 @@
 	}
 }
 
-.editor-styles-wrapper .gallery-caption {
+.gallery-caption {
 	display: block;
 }

--- a/varya/assets/sass/blocks/list/_editor.scss
+++ b/varya/assets/sass/blocks/list/_editor.scss
@@ -1,5 +1,5 @@
-.editor-styles-wrapper ul,
-.editor-styles-wrapper ol {
+ul,
+ol {
 	font-family: var(--list--font-family);
 	margin: var(--global--spacing-vertical) 0;
 	padding-left: calc( 2 * var(--global--spacing-horizontal) );
@@ -17,14 +17,14 @@
 	}
 }
 
-.editor-styles-wrapper li {
+li {
 	> ul,
 	> ol {
 		margin: 0;
 	}
 }
 
-.editor-styles-wrapper dt {
+dt {
 	font-family: var(--definition-term--font-family);
 	font-weight: bold;
 }

--- a/varya/assets/sass/blocks/paragraph/_editor.scss
+++ b/varya/assets/sass/blocks/paragraph/_editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper p {
+p {
 	&.has-background {
 		padding: var(--global--spacing-unit);
 

--- a/varya/assets/sass/blocks/posts-list/_editor.scss
+++ b/varya/assets/sass/blocks/posts-list/_editor.scss
@@ -1,3 +1,3 @@
-.editor-styles-wrapper .a8c-posts-list {
+.a8c-posts-list {
 	padding-left: 0;
 }

--- a/varya/assets/sass/blocks/pullquote/_editor.scss
+++ b/varya/assets/sass/blocks/pullquote/_editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-pullquote {
+.wp-block-pullquote {
 	padding: calc( 3 * var(--global--spacing-unit) ) 0;
 	margin-left: 0;
 	margin-right: 0;

--- a/varya/assets/sass/blocks/quote/_editor.scss
+++ b/varya/assets/sass/blocks/quote/_editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-quote {
+.wp-block-quote {
 	border-left-color: var(--quote--border-color);
 	margin: var(--global--spacing-vertical) 0;
 	padding-left: var(--global--spacing-horizontal);

--- a/varya/assets/sass/blocks/separator/_editor.scss
+++ b/varya/assets/sass/blocks/separator/_editor.scss
@@ -1,5 +1,5 @@
-.editor-styles-wrapper .wp-block-separator,
-.editor-styles-wrapper hr {
+.wp-block-separator,
+hr {
 	border-bottom: var(--separator--height) solid var(--separator--border-color);
 	clear: both;
 

--- a/varya/assets/sass/blocks/table/_editor.scss
+++ b/varya/assets/sass/blocks/table/_editor.scss
@@ -1,5 +1,5 @@
-.editor-styles-wrapper table,
-.editor-styles-wrapper .wp-block-table {
+table,
+.wp-block-table {
 
 	th {
 		font-family: var(--heading--font-family);

--- a/varya/assets/sass/blocks/utilities/_editor.scss
+++ b/varya/assets/sass/blocks/utilities/_editor.scss
@@ -1,7 +1,7 @@
 /**
- * Editor Post Title
- * - Needs a special styles
- */
+* Editor Post Title
+* - Needs a special styles
+*/
 
 .editor-post-title__block .editor-post-title__input {
 	color: var(--global--color-foreground);
@@ -12,149 +12,147 @@
 	line-height: var(--heading--line-height);
 }
 
-.editor-styles-wrapper {
-	// Gutenberg text color options
-	.has-text-color {}
+// Gutenberg text color options
+.has-text-color {}
 
-	.has-primary-color[class] {
-		color: var(--global--color-primary) !important;
+.has-primary-color[class] {
+	color: var(--global--color-primary) !important;
+}
+
+.has-secondary-color[class] {
+	color: var(--global--color-secondary) !important;
+}
+
+.has-foreground-color[class] {
+	color: var(--global--color-foreground) !important;
+}
+
+.has-foreground-light-color[class] {
+	color: var(--global--color-foreground-light) !important;
+}
+
+.has-foreground-dark-color[class] {
+	color: var(--global--color-foreground-dark) !important;
+}
+
+.has-background-light-color[class] {
+	color: var(--global--color-background-light) !important;
+}
+
+.has-background-dark-color[class] {
+	color: var(--global--color-background-dark) !important;
+}
+
+.has-background-color[class] {
+	color: var(--global--color-background) !important;
+}
+
+// Gutenberg background-color options
+.has-background {
+	&:not(.has-background-background-color) a,
+	p, h1, h2, h3, h4, h5, h6 {
+		color: currentColor;
 	}
+}
 
-	.has-secondary-color[class] {
-		color: var(--global--color-secondary) !important;
-	}
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary) !important;
+	color: var(--global--color-background);
+}
 
-	.has-foreground-color[class] {
-		color: var(--global--color-foreground) !important;
-	}
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary) !important;
+	color: var(--global--color-background);
+}
 
-	.has-foreground-light-color[class] {
-		color: var(--global--color-foreground-light) !important;
-	}
+.has-secondary-background-color[class] {
+	background-color: var(--global--color-secondary) !important;
+	color: var(--global--color-background);
+}
 
-	.has-foreground-dark-color[class] {
-		color: var(--global--color-foreground-dark) !important;
-	}
+.has-foreground-background-color[class] {
+	background-color: var(--global--color-foreground) !important;
+	color: var(--global--color-background);
+}
 
-	.has-background-light-color[class] {
-		color: var(--global--color-background-light) !important;
-	}
+.has-foreground-light-background-color[class] {
+	background-color: var(--global--color-foreground-light) !important;
+	color: var(--global--color-background);
+}
 
-	.has-background-dark-color[class] {
-		color: var(--global--color-background-dark) !important;
-	}
+.has-foreground-dark-background-color[class] {
+	background-color: var(--global--color-foreground-dark) !important;
+	color: var(--global--color-background);
+}
 
-	.has-background-color[class] {
-		color: var(--global--color-background) !important;
-	}
+.has-background-light-background-color[class] {
+	background-color: var(--global--color-background-light) !important;
+	color: var(--global--color-foreground);
+}
 
-	// Gutenberg background-color options
-	.has-background {
-		&:not(.has-background-background-color) a,
-		p, h1, h2, h3, h4, h5, h6 {
-			color: currentColor;
-		}
-	}
+.has-background-dark-background-color[class] {
+	background-color: var(--global--color-background-dark) !important;
+	color: var(--global--color-foreground);
+}
 
-	.has-primary-background-color[class] {
-		background-color: var(--global--color-primary) !important;
-		color: var(--global--color-background);
-	}
+.has-background-background-color[class] {
+	background-color: var(--global--color-background) !important;
+	color: var(--global--color-foreground);
+}
 
-	.has-primary-background-color[class] {
-		background-color: var(--global--color-primary) !important;
-		color: var(--global--color-background);
-	}
+.has-white-background-color[class] {
+	background-color: var(--global--color-white) !important;
+	color: var(--global--color-secondary);
+}
 
-	.has-secondary-background-color[class] {
-		background-color: var(--global--color-secondary) !important;
-		color: var(--global--color-background);
-	}
+.has-black-background-color[class] {
+	background-color: var(--global--color-black) !important;
+	color: var(--global--color-primary);
+}
 
-	.has-foreground-background-color[class] {
-		background-color: var(--global--color-foreground) !important;
-		color: var(--global--color-background);
-	}
+// Gutenberg Font-size utility classes
+.is-small-text,
+.has-small-font-size {
+	font-size: var(--global--font-size-sm);
+}
 
-	.has-foreground-light-background-color[class] {
-		background-color: var(--global--color-foreground-light) !important;
-		color: var(--global--color-background);
-	}
+.is-regular-text,
+.has-regular-font-size,
+.has-normal-font-size,
+.has-medium-font-size {
+	font-size: var(--global--font-size-md);
+}
 
-	.has-foreground-dark-background-color[class] {
-		background-color: var(--global--color-foreground-dark) !important;
-		color: var(--global--color-background);
-	}
+.is-large-text,
+.has-large-font-size {
+	font-size: var(--global--font-size-lg);
+	line-height: var(--global--line-height-heading);
+}
 
-	.has-background-light-background-color[class] {
-		background-color: var(--global--color-background-light) !important;
-		color: var(--global--color-foreground);
-	}
+.is-larger-text,
+.has-larger-font-size,
+.has-huge-font-size {
+	font-size: var(--global--font-size-xl);
+	line-height: var(--global--line-height-heading);
+}
 
-	.has-background-dark-background-color[class] {
-		background-color: var(--global--color-background-dark) !important;
-		color: var(--global--color-foreground);
-	}
+// Drop cap
+.has-drop-cap:not(:focus)::first-letter {
+	font-family: var(--heading--font-family);
+	font-size: calc(2 * var(--heading--font-size-h1));
+	font-weight: var(--heading--font-weight);
+}
 
-	.has-background-background-color[class] {
-		background-color: var(--global--color-background) !important;
-		color: var(--global--color-foreground);
-	}
+/**
+ * Spacing Overrides
+ */
 
-	.has-white-background-color[class] {
-		background-color: var(--global--color-white) !important;
-		color: var(--global--color-secondary);
-	}
+[data-block] {
+	margin-top: calc( 0.666 * var(--global--spacing-vertical) );
+	margin-bottom: calc( 0.666 * var(--global--spacing-vertical) );
 
-	.has-black-background-color[class] {
-		background-color: var(--global--color-black) !important;
-		color: var(--global--color-primary);
-	}
-
-	// Gutenberg Font-size utility classes
-	.is-small-text,
-	.has-small-font-size {
-		font-size: var(--global--font-size-sm);
-	}
-
-	.is-regular-text,
-	.has-regular-font-size,
-	.has-normal-font-size,
-	.has-medium-font-size {
-		font-size: var(--global--font-size-md);
-	}
-
-	.is-large-text,
-	.has-large-font-size {
-		font-size: var(--global--font-size-lg);
-		line-height: var(--global--line-height-heading);
-	}
-
-	.is-larger-text,
-	.has-larger-font-size,
-	.has-huge-font-size {
-		font-size: var(--global--font-size-xl);
-		line-height: var(--global--line-height-heading);
-	}
-
-	// Drop cap
-	.has-drop-cap:not(:focus)::first-letter {
-		font-family: var(--heading--font-family);
-		font-size: calc(2 * var(--heading--font-size-h1));
-		font-weight: var(--heading--font-weight);
-	}
-
-	/**
-	 * Spacing Overrides
-	 */
-
-	[data-block] {
-		margin-top: calc( 0.666 * var(--global--spacing-vertical) );
-		margin-bottom: calc( 0.666 * var(--global--spacing-vertical) );
-
-		@include media(mobile) {
-			margin-top: var(--global--spacing-vertical);
-			margin-bottom: var(--global--spacing-vertical);
-		}
+	@include media(mobile) {
+		margin-top: var(--global--spacing-vertical);
+		margin-bottom: var(--global--spacing-vertical);
 	}
 }

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -13,7 +13,7 @@
 /**
  * WooCommerce Variables
  */
-.editor-styles-wrapper {
+body {
 	/* Globals */
 	/* Font Family */
 	--global--font-primary: sans-serif;

--- a/varya/default-style/functions.php
+++ b/varya/default-style/functions.php
@@ -19,6 +19,13 @@ if ( ! function_exists( 'varya_default_setup' ) ) :
 	 */
 	function varya_default_setup() {
 
+		// Enqueue editor styles.
+		add_editor_style( array(
+			varya_default_fonts_url(),
+			'./default-style/variables.css',
+			'./default-style/variables-editor.css'
+		) );
+
 		add_theme_support(
 			'editor-font-sizes',
 			array(
@@ -140,35 +147,3 @@ function varya_default_fonts_url() {
 
 	return esc_url_raw( $fonts_url );
 }
-
-/**
- * Enqueue scripts and styles for the frontend.
- */
-function varya_default_variables() {
-
-	// Enqueue Google fonts
-	wp_enqueue_style( 'varya-default-fonts', varya_default_fonts_url(), array(), null );
-
-	// Default variables
-	wp_enqueue_style( 'varya-default-variables-style', get_template_directory_uri() . '/default-style/variables.css', array(), wp_get_theme()->get( 'Version' ) );
-
-	// Default extra styles
-	wp_enqueue_style( 'varya-default-extra-style', get_template_directory_uri() . '/default-style/style.css', array(), wp_get_theme()->get( 'Version' ) );
-
-}
-add_action( 'wp_enqueue_scripts', 'varya_default_variables' );
-
-/**
- * Enqueue scripts and styles for the editor.
- */
-function varya_editor_default_variables() {
-
-	// Enqueue Google fonts in the editor
-	wp_enqueue_style( 'varya-default-editor-fonts', varya_default_fonts_url(), array(), null );
-
-	// Default variables
-	wp_enqueue_style( 'varya-default-editor-variables-style', get_template_directory_uri() . '/default-style/variables-editor.css', array(), wp_get_theme()->get( 'Version' ) );
-
-}
-add_action( 'enqueue_block_editor_assets', 'varya_editor_default_variables' );
-

--- a/varya/default-style/functions.php
+++ b/varya/default-style/functions.php
@@ -147,3 +147,20 @@ function varya_default_fonts_url() {
 
 	return esc_url_raw( $fonts_url );
 }
+
+/**
+ * Enqueue scripts and styles for the frontend.
+ */
+function varya_default_variables() {
+
+	// Enqueue Google fonts
+	wp_enqueue_style( 'varya-default-fonts', varya_default_fonts_url(), array(), null );
+
+	// Default variables
+	wp_enqueue_style( 'varya-default-variables-style', get_template_directory_uri() . '/default-style/variables.css', array(), wp_get_theme()->get( 'Version' ) );
+
+	// Default extra styles
+	wp_enqueue_style( 'varya-default-extra-style', get_template_directory_uri() . '/default-style/style.css', array(), wp_get_theme()->get( 'Version' ) );
+
+}
+add_action( 'wp_enqueue_scripts', 'varya_default_variables' );

--- a/varya/functions.php
+++ b/varya/functions.php
@@ -104,10 +104,11 @@ if ( ! function_exists( 'varya_setup' ) ) :
 		// Add support for editor styles.
 		add_theme_support( 'editor-styles' );
 
-		// Do not enqueue editor styles here.
-		// Editor styles are loaded in `enqueue_block_editor_assets`
-		// See: varya_editor_theme_variables();
-		// add_editor_style( 'style-editor.css' );
+		// Enqueue editor styles.
+		add_editor_style( array(
+			'./assets/css/variables-editor.css',
+			'./assets/css/style-editor.css'
+		) );
 
 		// Add custom editor font sizes.
 		add_theme_support(
@@ -254,19 +255,6 @@ function varya_skip_link_focus_fix() {
 	<?php
 }
 add_action( 'wp_print_footer_scripts', 'varya_skip_link_focus_fix' );
-
-/**
- * Enqueue theme styles for the block editor.
- */
-function varya_editor_theme_variables() {
-
-	// Load the theme styles within Gutenberg.
-	wp_enqueue_style( 'varya-editor-variables', get_template_directory_uri() . '/assets/css/variables-editor.css', false, wp_get_theme()->get( 'Version' ), 'all' );
-
-	// Load the child theme styles within Gutenberg.
-	wp_enqueue_style( 'varya-editor-styles', get_template_directory_uri() . '/assets/css/style-editor.css', false, wp_get_theme()->get( 'Version' ), 'all' );
-}
-add_action( 'enqueue_block_editor_assets', 'varya_editor_theme_variables' );
 
 /**
  * SVG Icons class.


### PR DESCRIPTION
We should be using [the standard way](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#editor-styles) of enqueing the block editor stylesheets: `add_editor_style`. 

I'm not sure why Varya was using `enqueue_block_editor_assets` originally, but I'm not noticing any obvious issues swapping between this PR and the original one — the editor looks identical. 

Assuming there's no other technical limitation that requires use of `enqueue_block_editor_assets`, this just needs a little testing to ensure it's bringing in all the appropriate stylesheets still. 