### PR TITLE
Varya: Fix line-heights in editor and optimize editor stylesheet.

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -1,281 +1,14 @@
 /**
  * These styles should be loaded by the Block Editor only
  */
-/**
- * Layout
- * - Structral and responsive styles
- */
-/**
- * Repsonsive Styles
- */
-/**
- * Required Variables
- */
-/**
- * Root Media Query Variables
- */
-:root {
-	--responsive--spacing-horizontal: calc(2 * var(--global--spacing-horizontal));
-	--responsive--aligndefault-width: 100%;
-	--responsive--alignwide-width: 100%;
-	--responsive--alignfull-width: 100%;
-	--responsive--aligndefault-width: 100%;
-	--responsive--alignwide-width-multiplier: calc(16 * var(--global--spacing-horizontal));
-	--responsive--alignright-margin: var(--global--spacing-horizontal);
-	--responsive--alignleft-margin: var(--global--spacing-horizontal);
-}
-
-@media only screen and (min-width: 560px) {
-	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-@media only screen and (min-width: 640px) {
-	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-@media only screen and (min-width: 782px) {
-	:root {
-		--responsive--aligndefault-width: calc(640px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px - var(--responsive--spacing-horizontal));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-@media only screen and (min-width: 1024px) {
-	:root {
-		--responsive--aligndefault-width: calc(782px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px + var(--responsive--alignwide-width-multiplier));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-@media only screen and (min-width: $breakpoint_xxl) {
-	:root {
-		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-/**
- * Extends
- */
-.default-max-width {
-	max-width: var(--responsive--aligndefault-width);
-	margin-left: auto;
-	margin-right: auto;
-}
-
-.wide-max-width {
-	max-width: var(--responsive--alignwide-width);
-	margin-left: auto;
-	margin-right: auto;
-}
-
-.full-max-width {
-	max-width: var(--responsive--alignfull-width);
-	margin-left: auto;
-	margin-right: auto;
-}
-
-/**
- * Output
- */
-/**
- * Site Structure
- *
- * - Set vertical margins and responsive widths on
- *   top-level wrappers and content wrappers
- * - `--global--width-content` is a responsive veriable
- * - See: globals/_global-width-responsive.scss
- */
-/**
- * Top Level Wrappers (header, main, footer)
- * - Set vertical padding and horizontal margins
- */
-.site-header,
-.site-main,
-.site-footer {
-	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
-	margin-left: auto;
-	margin-right: auto;
-}
-
-@media only screen and (min-width: 560px) {
-	.site-header,
-	.site-main,
-	.site-footer {
-		padding-top: var(--global--spacing-vertical);
-		padding-right: 0;
-		padding-bottom: var(--global--spacing-vertical);
-		padding-left: 0;
-	}
-}
-
-/**
- * Site-main children wrappers
- * - Add double vertical margins here for clearer heirarchy
- */
-.site-main > * {
-	margin-top: calc(3 * var(--global--spacing-vertical));
-	margin-bottom: calc(3 * var(--global--spacing-vertical));
-}
-
-.site-main > *:first-child {
-	margin-top: 0;
-}
-
-.site-main > *:last-child {
-	margin-bottom: 0;
-}
-
-/**
- * Set the default maximum responsive content-width
- */
-/**
- * Set the wide maximum responsive content-width
- */
-/**
- * Set the full maximum responsive content-width
- */
-/*
- * Block & non-gutenberg content wrappers
- * - Set margins
- */
-.entry-header,
-.post-thumbnail,
-.entry-content,
-.entry-footer,
-.author-bio,
-.widget-area {
-	margin-top: var(--global--spacing-vertical);
-	margin-right: auto;
-	margin-bottom: var(--global--spacing-vertical);
-	margin-left: auto;
-}
-
-/*
- * Block & non-gutenberg content wrapper children
- * - Sets spacing-vertical margin logic
- */
-.site-footer > *,
-.site-main > article > *,
-.site-main > .not-found > *,
-.entry-content > *,
-[class*="inner-container"] > *,
-.widget-area > * {
-	margin-top: calc( 0.666 * var(--global--spacing-vertical));
-	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
-}
-
-@media only screen and (min-width: 560px) {
-	.site-footer > *,
-	.site-main > article > *,
-	.site-main > .not-found > *,
-	.entry-content > *,
-	[class*="inner-container"] > *,
-	.widget-area > * {
-		margin-top: var(--global--spacing-vertical);
-		margin-bottom: var(--global--spacing-vertical);
-	}
-}
-
-.site-footer > *:first-child,
-.site-main > article > *:first-child,
-.site-main > .not-found > *:first-child,
-.entry-content > *:first-child,
-[class*="inner-container"] > *:first-child,
-.widget-area > *:first-child {
-	margin-top: 0;
-}
-
-.site-footer > *:last-child,
-.site-main > article > *:last-child,
-.site-main > .not-found > *:last-child,
-.entry-content > *:last-child,
-[class*="inner-container"] > *:last-child,
-.widget-area > *:last-child {
-	margin-bottom: 0;
-}
-
-/*
- * Block & non-gutenberg content wrapper children
- * - Sets spacing-unit margins
- */
-.site-header > *,
-.entry-header > *,
-.post-thumbnail > *,
-.page-content > *,
-.comment-content > *,
-.author-bio > *,
-.widget-area > .widget > * {
-	margin-top: var(--global--spacing-unit);
-	margin-bottom: var(--global--spacing-unit);
-}
-
-.site-header > *:first-child,
-.entry-header > *:first-child,
-.post-thumbnail > *:first-child,
-.page-content > *:first-child,
-.comment-content > *:first-child,
-.author-bio > *:first-child,
-.widget-area > .widget > *:first-child {
-	margin-top: 0;
-}
-
-.site-header > *:last-child,
-.entry-header > *:last-child,
-.post-thumbnail > *:last-child,
-.page-content > *:last-child,
-.comment-content > *:last-child,
-.author-bio > *:last-child,
-.widget-area > .widget > *:last-child {
-	margin-bottom: 0;
-}
-
-/*
- * .entry-content children specific controls
- * - Adds special margin overrides for alignment utility classes
- */
-.entry-content > * {
-	/* Reset alignleft and alignright margins after alignfull */
-}
-
-.entry-content > *.alignleft, .entry-content > *.alignright,
-.entry-content > *.alignleft:first-child + *,
-.entry-content > *.alignright:first-child + *, .entry-content > *.alignfull {
-	margin-top: 0;
-}
-
-.entry-content > *:last-child, .entry-content > *.alignfull {
-	margin-bottom: 0;
-}
-
-.entry-content > *.alignfull + .alignleft,
-.entry-content > *.alignfull + .alignright {
-	margin-top: var(--global--spacing-vertical);
-}
-
-body {
+body,
+p {
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);
 	font-size: var(--global--font-size-root);
 	font-weight: normal;
-	line-height: var(--global--font-line-height-body);
+	line-height: var(--global--line-height-body);
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 }
@@ -410,13 +143,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(2 * var(--global--spacing-vertical));
-}
-
-@media only screen and (min-width: 560px) {
-	.wp-block-a8c-blog-posts article {
-		margin-bottom: calc(3 * var(--global--spacing-vertical));
-	}
+	margin-bottom: calc(3 * var(--global--spacing-vertical));
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -700,13 +427,7 @@ object {
 }
 
 .wp-block-group.has-background {
-	padding: calc( 0.666 * var(--global--spacing-vertical));
-}
-
-@media only screen and (min-width: 560px) {
-	.wp-block-group.has-background {
-		padding: var(--global--spacing-vertical);
-	}
+	padding: var(--global--spacing-vertical);
 }
 
 .wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
@@ -922,13 +643,6 @@ dt {
 .wp-block-media-text .block-editor-inner-blocks {
 	padding-right: var(--global--spacing-horizontal);
 	padding-left: var(--global--spacing-horizontal);
-}
-
-@media only screen and (min-width: 640px) {
-	.wp-block-media-text .block-editor-inner-blocks {
-		padding-right: var(--global--spacing-vertical);
-		padding-left: var(--global--spacing-vertical);
-	}
 }
 
 .wp-block-media-text[style*="background-color"]:not(.has-background-background-color) a {
@@ -1264,13 +978,6 @@ table th,
  * Spacing Overrides
  */
 [data-block] {
-	margin-top: calc( 0.666 * var(--global--spacing-vertical));
-	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
-}
-
-@media only screen and (min-width: 560px) {
-	[data-block] {
-		margin-top: var(--global--spacing-vertical);
-		margin-bottom: var(--global--spacing-vertical);
-	}
+	margin-top: var(--global--spacing-vertical);
+	margin-bottom: var(--global--spacing-vertical);
 }

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -1,16 +1,18 @@
 /**
  * These styles should be loaded by the Block Editor only
  */
-body,
-p {
+body {
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);
 	font-size: var(--global--font-size-root);
 	font-weight: normal;
-	line-height: var(--global--line-height-body);
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
+}
+
+p {
+	line-height: var(--global--line-height-body);
 }
 
 .editor-post-title__block {

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -8,16 +8,6 @@
 /**
  * Required Variables
  */
-@custom-media --sm only screen and (min-width: 560px);
-@custom-media --md only screen and (min-width: 640px);
-@custom-media --lg only screen and (min-width: 782px);
-@custom-media --xl only screen and (min-width: 1024px);
-@custom-media --xxl only screen and (min-width: $breakpoint_xxl);
-@custom-media --sm-max only screen and (max-width: 559px);
-@custom-media --md-max only screen and (max-width: 639px);
-@custom-media --lg-max only screen and (max-width: 781px);
-@custom-media --xl-max only screen and (max-width: 1023px);
-@custom-media --xxl-max only screen and (max-width: 1279px);
 /**
  * Root Media Query Variables
  */
@@ -32,7 +22,7 @@
 	--responsive--alignleft-margin: var(--global--spacing-horizontal);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	:root {
 		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
@@ -41,7 +31,7 @@
 	}
 }
 
-@media (--md) {
+@media only screen and (min-width: 640px) {
 	:root {
 		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
@@ -50,7 +40,7 @@
 	}
 }
 
-@media (--lg) {
+@media only screen and (min-width: 782px) {
 	:root {
 		--responsive--aligndefault-width: calc(640px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(782px - var(--responsive--spacing-horizontal));
@@ -59,7 +49,7 @@
 	}
 }
 
-@media (--xl) {
+@media only screen and (min-width: 1024px) {
 	:root {
 		--responsive--aligndefault-width: calc(782px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(782px + var(--responsive--alignwide-width-multiplier));
@@ -68,7 +58,7 @@
 	}
 }
 
-@media (--xxl) {
+@media only screen and (min-width: 1280px {
 	:root {
 		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));
@@ -128,7 +118,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-left: auto;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.site-header,
 	.site-main,
 	.site-footer {
@@ -195,7 +185,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.site-footer > *,
 	.site-main > article > *,
 	.site-main > .not-found > *,
@@ -900,7 +890,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	display: inline;
 }
 
-@media (--sm-max) {
+@media only screen and (max-width: 559px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);
 		color: var(--wc--mini-cart--color-text);
@@ -914,7 +904,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	}
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .main-navigation > div:not(:last-of-type) {
 		margin-left: calc(2 * var(--global--spacing-unit));
 	}
@@ -949,7 +939,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 	vertical-align: middle;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link {
 		display: inline-block;
 	}
@@ -962,7 +952,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 	padding: var(--primary-nav--padding) 0;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 		max-width: calc(20 * var(--global--spacing-horizontal));
 		padding: var(--primary-nav--padding);
@@ -1044,7 +1034,7 @@ body[class*="woocommerce"] #page .main-navigation ul.product_list_widget li .qua
 	font-size: var(--global--font-size-base);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .main-navigation > div > ul > li.woocommerce-menu-item > .sub-menu {
 		right: auto;
 		left: 0;
@@ -1626,7 +1616,7 @@ body[class*="woocommerce"] #page table.shop_table td.product-remove {
 	border-width: 0;
 }
 
-@media (--xl) {
+@media only screen and (min-width: 1024px) {
 	body[class*="woocommerce"] #page table.shop_table td.product-remove {
 		height: var(--global--font-size-sm);
 		width: var(--global--font-size-sm);
@@ -1911,7 +1901,7 @@ body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigatio
 	margin-top: 0;
 }
 
-@media (--md) {
+@media only screen and (min-width: 640px) {
 	body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigation {
 		width: 20%;
 	}
@@ -1931,7 +1921,7 @@ body[class*="woocommerce"] #page .woocommerce-MyAccount-content fieldset {
 	border-radius: 3px;
 }
 
-@media (--md) {
+@media only screen and (min-width: 640px) {
 	body[class*="woocommerce"] #page .woocommerce-MyAccount-content {
 		width: calc(80% - var(--global--spacing-horizontal));
 	}
@@ -2207,7 +2197,7 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 /**
  * Filter by Product List Widgets
  */
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .widget.woocommerce ul.product_list_widget:not(.woocommerce-mini-cart) {
 		display: flex;
 		flex-wrap: wrap;

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -58,7 +58,7 @@
 	}
 }
 
-@media only screen and (min-width: 1280px {
+@media only screen and (min-width: 1280px) {
 	:root {
 		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -58,7 +58,7 @@
 	}
 }
 
-@media only screen and (min-width: $breakpoint_xxl) {
+@media only screen and (min-width: 1280px {
 	:root {
 		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -58,7 +58,7 @@
 	}
 }
 
-@media only screen and (min-width: 1280px {
+@media only screen and (min-width: 1280px) {
 	:root {
 		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -34,7 +34,7 @@ body {
 	--global--font-size-xxxxl: calc(var(--global--font-size-base) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio));
 	/* Line Height */
 	--global--line-height-base: 1;
-	--global--line-height-body: 1.78;
+	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.125;
 	/* Colors */
 	--global--color-primary: blue;

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -34,7 +34,7 @@
 	--global--font-size-xxxxl: calc(var(--global--font-size-base) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio));
 	/* Line Height */
 	--global--line-height-base: 1;
-	--global--line-height-body: 1.78;
+	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.125;
 	/* Colors */
 	--global--color-primary: blue;

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -29,7 +29,7 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 
 	/* Line Height */
 	--global--line-height-base: #{$typescale-base / ( $typescale-base * 0 + 1 )};
-	--global--line-height-body: 1.78;
+	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.125;
 
 	/* Colors */

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -1,10 +1,11 @@
-body {
+body,
+p {
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);
 	font-size: var(--global--font-size-root);
 	font-weight: normal;
-	line-height: var(--global--font-line-height-body);
+	line-height: var(--global--line-height-body);
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 }

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -1,13 +1,15 @@
-body,
-p {
+body {
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);
 	font-size: var(--global--font-size-root);
 	font-weight: normal;
-	line-height: var(--global--line-height-body);
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
+}
+
+p {
+	line-height: var(--global--line-height-body);
 }
 
 // Set font size of title block the same as body.

--- a/varya/assets/sass/blocks/blog-posts/_editor.scss
+++ b/varya/assets/sass/blocks/blog-posts/_editor.scss
@@ -38,11 +38,7 @@
 	}
 
 	article {
-		margin-bottom: calc(2 * var(--global--spacing-vertical));
-
-		@include media(mobile) {
-			margin-bottom: calc(3 * var(--global--spacing-vertical));
-		}
+		margin-bottom: calc(3 * var(--global--spacing-vertical));
 	}
 
 	.post-thumbnail {

--- a/varya/assets/sass/blocks/group/_editor.scss
+++ b/varya/assets/sass/blocks/group/_editor.scss
@@ -1,10 +1,6 @@
 .wp-block-group {
 	&.has-background {
-		padding: calc( 0.666 * var(--global--spacing-vertical) );
-
-		@include media(mobile) {
-			padding: var(--global--spacing-vertical);
-		}
+		padding: var(--global--spacing-vertical);
 	}
 }
 

--- a/varya/assets/sass/blocks/media-text/_editor.scss
+++ b/varya/assets/sass/blocks/media-text/_editor.scss
@@ -2,11 +2,6 @@
 	.block-editor-inner-blocks {
 		padding-right: var(--global--spacing-horizontal);
 		padding-left: var(--global--spacing-horizontal);
-
-		@include media(tablet) {
-			padding-right: var(--global--spacing-vertical);
-			padding-left: var(--global--spacing-vertical);
-		}
 	}
 
 	&[style*="background-color"]:not(.has-background-background-color) {

--- a/varya/assets/sass/blocks/utilities/_editor.scss
+++ b/varya/assets/sass/blocks/utilities/_editor.scss
@@ -148,11 +148,6 @@
  */
 
 [data-block] {
-	margin-top: calc( 0.666 * var(--global--spacing-vertical) );
-	margin-bottom: calc( 0.666 * var(--global--spacing-vertical) );
-
-	@include media(mobile) {
-		margin-top: var(--global--spacing-vertical);
-		margin-bottom: var(--global--spacing-vertical);
-	}
+	margin-top: var(--global--spacing-vertical);
+	margin-bottom: var(--global--spacing-vertical);
 }

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -34,7 +34,7 @@ body {
 	--global--font-size-xxxxl: calc(var(--global--font-size-base) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio));
 	/* Line Height */
 	--global--line-height-base: 1;
-	--global--line-height-body: 1.78;
+	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.125;
 	/* Colors */
 	--global--color-primary: blue;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -34,7 +34,7 @@
 	--global--font-size-xxxxl: calc(var(--global--font-size-base) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio) * var(--global--font-size-ratio));
 	/* Line Height */
 	--global--line-height-base: 1;
-	--global--line-height-body: 1.78;
+	--global--line-height-body: 1.7;
 	--global--line-height-heading: 1.125;
 	/* Colors */
 	--global--color-primary: blue;

--- a/varya/assets/sass/structure/_responsive-logic.scss
+++ b/varya/assets/sass/structure/_responsive-logic.scss
@@ -18,7 +18,7 @@ $breakpoint_xxl: 1280px;
 @custom-media --md only screen and (min-width: #{$breakpoint_md});
 @custom-media --lg only screen and (min-width: #{$breakpoint_lg});
 @custom-media --xl only screen and (min-width: #{$breakpoint_xl});
-@custom-media --xxl only screen and (min-width: $breakpoint_xxl);
+@custom-media --xxl only screen and (min-width: #{$breakpoint_xxl)};
 
 @custom-media --sm-max only screen and (max-width: #{$breakpoint_sm - 1});
 @custom-media --md-max only screen and (max-width: #{$breakpoint_md - 1});

--- a/varya/assets/sass/structure/_responsive-logic.scss
+++ b/varya/assets/sass/structure/_responsive-logic.scss
@@ -18,7 +18,7 @@ $breakpoint_xxl: 1280px;
 @custom-media --md only screen and (min-width: #{$breakpoint_md});
 @custom-media --lg only screen and (min-width: #{$breakpoint_lg});
 @custom-media --xl only screen and (min-width: #{$breakpoint_xl});
-@custom-media --xxl only screen and (min-width: #{$breakpoint_xxl)};
+@custom-media --xxl only screen and (min-width: #{$breakpoint_xxl});
 
 @custom-media --sm-max only screen and (max-width: #{$breakpoint_sm - 1});
 @custom-media --md-max only screen and (max-width: #{$breakpoint_md - 1});

--- a/varya/assets/sass/style-editor.scss
+++ b/varya/assets/sass/style-editor.scss
@@ -2,14 +2,10 @@
  * These styles should be loaded by the Block Editor only
  */
 
-// Layout
-// - Structral and responsive styles
-@import "structure/style";
-@import "abstracts/mixins";
-
 // Abstracts
 // - Mixins, variables and functions
-@import "abstracts/editor";
+@import "abstracts/functions";
+@import "abstracts/mixins";
 
 // Base
 // - Reset the browser

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -31,16 +31,6 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 /**
  * Required Variables
  */
-@custom-media --sm only screen and (min-width: 560px);
-@custom-media --md only screen and (min-width: 640px);
-@custom-media --lg only screen and (min-width: 782px);
-@custom-media --xl only screen and (min-width: 1024px);
-@custom-media --xxl only screen and (min-width: $breakpoint_xxl);
-@custom-media --sm-max only screen and (max-width: 559px);
-@custom-media --md-max only screen and (max-width: 639px);
-@custom-media --lg-max only screen and (max-width: 781px);
-@custom-media --xl-max only screen and (max-width: 1023px);
-@custom-media --xxl-max only screen and (max-width: 1279px);
 /**
  * Root Media Query Variables
  */
@@ -55,7 +45,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	--responsive--alignleft-margin: var(--global--spacing-horizontal);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	:root {
 		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
@@ -64,7 +54,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-@media (--md) {
+@media only screen and (min-width: 640px) {
 	:root {
 		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
@@ -73,7 +63,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-@media (--lg) {
+@media only screen and (min-width: 782px) {
 	:root {
 		--responsive--aligndefault-width: calc(640px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(782px - var(--responsive--spacing-horizontal));
@@ -82,7 +72,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-@media (--xl) {
+@media only screen and (min-width: 1024px) {
 	:root {
 		--responsive--aligndefault-width: calc(782px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(782px + var(--responsive--alignwide-width-multiplier));
@@ -91,7 +81,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-@media (--xxl) {
+@media only screen and (min-width: 1280px {
 	:root {
 		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));
@@ -144,7 +134,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-right: var(--responsive--spacing-horizontal);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.entry-content .wp-block-button.alignright, .entry-content > .alignleft {
 		margin-left: auto;
 		margin-right: var(--responsive--alignleft-margin);
@@ -156,7 +146,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-right: 0;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.entry-content .wp-block-button.alignleft, .entry-content > .alignright {
 		margin-left: var(--responsive--alignright-margin);
 		margin-right: auto;
@@ -186,7 +176,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-left: auto;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.site-header,
 	.site-main,
 	.site-footer {
@@ -253,7 +243,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.site-footer > *,
 	.site-main > article > *,
 	.site-main > .not-found > *,
@@ -816,7 +806,7 @@ html {
 	line-height: var(--global--line-height-body);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	html {
 		font-size: var(--global--font-size-root);
 	}
@@ -1107,7 +1097,7 @@ object {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-newspack-blocks-homepage-articles.is-grid article {
 		margin-bottom: calc(3 * var(--global--spacing-vertical));
 	}
@@ -1129,7 +1119,7 @@ object {
 	margin-bottom: calc(2 * var(--global--spacing-vertical));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-newspack-blocks-homepage-articles article {
 		margin-top: calc(3 * var(--global--spacing-vertical));
 		margin-bottom: calc(3 * var(--global--spacing-vertical));
@@ -1183,7 +1173,7 @@ object {
 	color: currentColor;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-newspack-blocks-homepage-articles article .more-link {
 		margin-top: var(--global--spacing-unit);
 	}
@@ -1532,7 +1522,7 @@ button[data-load-more-btn],
 	margin-bottom: calc(0.66 * var(--global--spacing-vertical));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-columns .wp-block-column > * {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
@@ -1555,13 +1545,13 @@ button[data-load-more-btn],
 	margin-bottom: calc(0.66 * var(--global--spacing-vertical));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-columns .wp-block-column:not(:last-child) {
 		margin-bottom: var(--global--spacing-vertical);
 	}
 }
 
-@media (--lg) {
+@media only screen and (min-width: 782px) {
 	.wp-block-columns .wp-block-column:not(:last-child) {
 		/* Resetting margins to match _block-container.scss */
 		margin-bottom: 0;
@@ -1651,7 +1641,7 @@ button[data-load-more-btn],
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-cover .wp-block-cover__inner-container > *,
 	.wp-block-cover-image .wp-block-cover__inner-container > * {
 		margin-top: var(--global--spacing-vertical);
@@ -1742,7 +1732,7 @@ button[data-load-more-btn],
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-group .wp-block-group__inner-container > * {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
@@ -1761,7 +1751,7 @@ button[data-load-more-btn],
 	padding: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-group.has-background {
 		padding: var(--global--spacing-vertical);
 	}
@@ -2078,7 +2068,7 @@ dd {
 	padding: var(--global--spacing-horizontal);
 }
 
-@media (--md) {
+@media only screen and (min-width: 640px) {
 	.wp-block-media-text .wp-block-media-text__content {
 		padding: var(--global--spacing-vertical);
 	}
@@ -2089,7 +2079,7 @@ dd {
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-media-text .wp-block-media-text__content > * {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
@@ -2108,7 +2098,7 @@ dd {
 	color: currentColor;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__content {
 		padding-top: var(--global--spacing-vertical);
 		padding-bottom: var(--global--spacing-vertical);
@@ -2400,7 +2390,7 @@ hr.wp-block-separator.is-style-dots:before {
 	margin-top: 0 !important;
 }
 
-@media (--sm-max) {
+@media only screen and (max-width: 559px) {
 	.wp-block-spacer[style] {
 		height: var(--global--spacing-unit) !important;
 	}
@@ -2656,7 +2646,7 @@ table th,
 	display: none;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.desktop-only {
 		display: block;
 	}
@@ -2838,7 +2828,7 @@ table th,
 	display: inline;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.main-navigation > div {
 		display: inline-block;
 	}
@@ -2877,7 +2867,7 @@ table th,
 	z-index: 99999;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.main-navigation > div > ul li {
 		display: inherit;
 		width: inherit;
@@ -2893,7 +2883,7 @@ table th,
 	}
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.main-navigation > div > ul > li > a {
 		line-height: var(--global--line-height-base);
 	}
@@ -2922,7 +2912,7 @@ table th,
 	position: relative;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.main-navigation > div > ul > li > .sub-menu {
 		background: var(--global--color-background);
 		box-shadow: var(--global--elevation-4);
@@ -2948,7 +2938,7 @@ table th,
 	padding: calc(0.5 * var(--primary-nav--padding)) 0;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.main-navigation a {
 		padding: var(--primary-nav--padding);
 	}
@@ -2981,7 +2971,7 @@ table th,
 	content: "– " counters(nested-list, "– ", none);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.main-navigation > div > ul > .menu-item-has-children > a::after {
 		content: "\00a0\25BC";
 		display: inline-block;
@@ -3036,7 +3026,7 @@ table th,
 	overflow: hidden;
 }
 
-@media (--xl) {
+@media only screen and (min-width: 1024px) {
 	.site-footer {
 		align-items: flex-end;
 		display: flex;
@@ -3052,7 +3042,7 @@ table th,
 	line-height: var(--global--line-height-body);
 }
 
-@media (--xl) {
+@media only screen and (min-width: 1024px) {
 	.site-footer > .site-info {
 		order: 1;
 		flex: 1 0 50%;
@@ -3081,7 +3071,7 @@ table th,
 	display: inline;
 }
 
-@media (--xl) {
+@media only screen and (min-width: 1024px) {
 	.site-footer > .footer-navigation {
 		flex: 1 0 50%;
 		order: 2;
@@ -3101,7 +3091,7 @@ table th,
 	padding-right: 0;
 }
 
-@media (--xl) {
+@media only screen and (min-width: 1024px) {
 	.site-footer > .footer-navigation .footer-menu {
 		display: flex;
 		flex-wrap: wrap;
@@ -3173,7 +3163,7 @@ table th,
 	margin-top: var(--global--spacing-unit);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.entry-content .more-link {
 		margin-top: var(--global--spacing-vertical);
 	}
@@ -3194,7 +3184,7 @@ table th,
 	max-width: 100% !important;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.entry-content > iframe[style] {
 		max-width: var(--global--spacing-vertical) !important;
 	}
@@ -3294,7 +3284,7 @@ table th,
 	color: var(--global--color-primary-hover);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.navigation .nav-links {
 		display: flex;
 		justify-content: center;
@@ -3329,7 +3319,7 @@ table th,
 	font-weight: 600;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.post-navigation .nav-links {
 		justify-content: space-between;
 	}
@@ -3439,7 +3429,7 @@ table th,
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.comment-list .children {
 		padding-right: calc(2 * var(--global--spacing-horizontal));
 	}
@@ -3459,7 +3449,7 @@ table th,
 	max-width: calc(100% - (3 * var(--global--spacing-horizontal)));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.comment-meta .comment-author {
 		display: flex;
 		align-items: center;
@@ -3485,7 +3475,7 @@ table th,
 	padding-left: calc(2.5 * var(--global--spacing-horizontal));
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.comment-meta .comment-metadata {
 		padding-left: 0;
 	}
@@ -3499,7 +3489,7 @@ table th,
 	color: var(--global--color-primary-hover);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.comment-meta {
 		margin-left: inherit;
 		align-items: center;
@@ -3536,7 +3526,7 @@ table th,
 	text-align: left;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.reply {
 		text-align: right;
 	}
@@ -3617,7 +3607,7 @@ table th,
 	width: auto;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	.comment-form > p {
 		display: flex;
 	}
@@ -4137,7 +4127,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	display: inline;
 }
 
-@media (--sm-max) {
+@media only screen and (max-width: 559px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);
 		color: var(--wc--mini-cart--color-text);
@@ -4151,7 +4141,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	}
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .main-navigation > div:not(:last-of-type) {
 		margin-left: calc(2 * var(--global--spacing-unit));
 	}
@@ -4186,7 +4176,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 	vertical-align: middle;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link {
 		display: inline-block;
 	}
@@ -4199,7 +4189,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 	padding: var(--primary-nav--padding) 0;
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 		max-width: calc(20 * var(--global--spacing-horizontal));
 		padding: var(--primary-nav--padding);
@@ -4281,7 +4271,7 @@ body[class*="woocommerce"] #page .main-navigation ul.product_list_widget li .qua
 	font-size: var(--global--font-size-base);
 }
 
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .main-navigation > div > ul > li.woocommerce-menu-item > .sub-menu {
 		right: auto;
 		left: 0;
@@ -4863,7 +4853,7 @@ body[class*="woocommerce"] #page table.shop_table td.product-remove {
 	border-width: 0;
 }
 
-@media (--xl) {
+@media only screen and (min-width: 1024px) {
 	body[class*="woocommerce"] #page table.shop_table td.product-remove {
 		height: var(--global--font-size-sm);
 		width: var(--global--font-size-sm);
@@ -5148,7 +5138,7 @@ body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigatio
 	margin-top: 0;
 }
 
-@media (--md) {
+@media only screen and (min-width: 640px) {
 	body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigation {
 		width: 20%;
 	}
@@ -5168,7 +5158,7 @@ body[class*="woocommerce"] #page .woocommerce-MyAccount-content fieldset {
 	border-radius: 3px;
 }
 
-@media (--md) {
+@media only screen and (min-width: 640px) {
 	body[class*="woocommerce"] #page .woocommerce-MyAccount-content {
 		width: calc(80% - var(--global--spacing-horizontal));
 	}
@@ -5444,7 +5434,7 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 /**
  * Filter by Product List Widgets
  */
-@media (--sm) {
+@media only screen and (min-width: 560px) {
 	body[class*="woocommerce"] #page .widget.woocommerce ul.product_list_widget:not(.woocommerce-mini-cart) {
 		display: flex;
 		flex-wrap: wrap;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -81,7 +81,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-@media only screen and (min-width: 1280px {
+@media only screen and (min-width: 1280px) {
 	:root {
 		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));

--- a/varya/style.css
+++ b/varya/style.css
@@ -81,7 +81,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-@media only screen and (min-width: 1280px {
+@media only screen and (min-width: 1280px) {
 	:root {
 		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));

--- a/varya/style.css
+++ b/varya/style.css
@@ -81,7 +81,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-@media only screen and (min-width: $breakpoint_xxl) {
+@media only screen and (min-width: 1280px {
 	:root {
 		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
 		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));


### PR DESCRIPTION
- Optimizes the editor styles to remove a bunch of structural, header and footer rules that aren’t relevant for the editor. 
- Fixes the editor selectors so that the correct line-height for `--global--line-height-body` value is applied.
- Fixes a small typo that broke responsive styles on larger screens.

Before:
![image](https://user-images.githubusercontent.com/709581/77788400-91cf1000-7037-11ea-9109-c153ee82bf42.png)

After: 
![image](https://user-images.githubusercontent.com/709581/77788325-6d733380-7037-11ea-8d8f-5bf4abecb79a.png)
