### PR TITLE
[Varya] Update site header styles

### DIFF
--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -129,6 +129,11 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	}
 }
 
+.site-header {
+	padding-top: calc(3 * var(--global--spacing-vertical));
+	padding-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
 /**
  * Site-main children wrappers
  * - Add double vertical margins here for clearer heirarchy

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -129,6 +129,11 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	}
 }
 
+.site-header {
+	padding-top: calc(3 * var(--global--spacing-vertical));
+	padding-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
 /**
  * Site-main children wrappers
  * - Add double vertical margins here for clearer heirarchy

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -155,6 +155,8 @@
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
+	--branding--logo--border-radius: 50%;
+	--branding--logo--max-width: 128px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -151,7 +151,7 @@
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--heading--font-size-h1);
-	--branding--title--font-weight: normal;
+	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -155,6 +155,8 @@
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
+	--branding--logo--border-radius: 50%;
+	--branding--logo--max-width: 128px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -151,7 +151,7 @@
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--heading--font-size-h1);
-	--branding--title--font-weight: normal;
+	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -4,7 +4,7 @@
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--heading--font-size-h1);
-	--branding--title--font-weight: normal;
+	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -9,8 +9,8 @@
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
 
-	--branding--logo--border-radius: 50%;
 	--branding--logo--max-width: 128px;
+	--branding--logo--max-height: 128px;
 
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -9,6 +9,9 @@
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
 
+	--branding--logo--border-radius: 50%;
+	--branding--logo--max-width: 128px;
+
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -61,8 +61,8 @@ nav a {
 	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
 
 	.custom-logo {
-		border-radius: var(--branding--logo--border-radius);
 		max-width: var(--branding--logo--max-width);
+		max-height: var(--branding--logo--max-width);
 		height: auto;
 	}
 }

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -57,10 +57,8 @@ nav a {
 }
 
 .site-title > a {
-	text-decoration: underline;
 	text-underline-width: .125em;
 	text-decoration-color: var(--global--color-secondary);
-	border-bottom: none;
 }
 
 // Site logo

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -8,6 +8,7 @@
 
 .site-branding {
 	color: var(--branding--color-text);
+	text-align: center;
 }
 
 // Site title
@@ -19,6 +20,7 @@
 	font-size: var(--branding--title--font-size);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
+	margin-bottom: var(--global--spacing-vertical);
 
 	a {
 		color: currentColor;
@@ -59,4 +61,16 @@ nav a {
 	text-underline-width: .125em;
 	text-decoration-color: var(--global--color-secondary);
 	border-bottom: none;
+}
+
+// Site logo
+
+.site-logo {
+	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+
+	.custom-logo {
+		border-radius: var(--branding--logo--border-radius);
+		max-width: var(--branding--logo--max-width);
+		height: auto;
+	}
 }

--- a/varya/assets/sass/structure/_vertical-margins.scss
+++ b/varya/assets/sass/structure/_vertical-margins.scss
@@ -26,6 +26,11 @@
 	}
 }
 
+.site-header {
+	padding-top: calc(3 * var(--global--spacing-vertical));
+	padding-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
 /**
  * Site-main children wrappers
  * - Add double vertical margins here for clearer heirarchy

--- a/varya/functions.php
+++ b/varya/functions.php
@@ -85,8 +85,8 @@ if ( ! function_exists( 'varya_setup' ) ) :
 		add_theme_support(
 			'custom-logo',
 			array(
-				'height'      => 190,
-				'width'       => 190,
+				'height'      => 128,
+				'width'       => 128,
 				'flex-width'  => false,
 				'flex-height' => false,
 			)

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2818,10 +2818,8 @@ nav a {
 }
 
 .site-title > a {
-	text-decoration: underline;
 	text-underline-width: .125em;
 	text-decoration-color: var(--global--color-secondary);
-	border-bottom: none;
 }
 
 .site-logo {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -187,6 +187,11 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	}
 }
 
+.site-header {
+	padding-top: calc(3 * var(--global--spacing-vertical));
+	padding-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
 /**
  * Site-main children wrappers
  * - Add double vertical margins here for clearer heirarchy
@@ -2770,6 +2775,7 @@ table th,
  */
 .site-branding {
 	color: var(--branding--color-text);
+	text-align: center;
 }
 
 .site-title {
@@ -2778,6 +2784,7 @@ table th,
 	font-size: var(--branding--title--font-size);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
+	margin-bottom: var(--global--spacing-vertical);
 }
 
 .site-title a {
@@ -2815,6 +2822,16 @@ nav a {
 	text-underline-width: .125em;
 	text-decoration-color: var(--global--color-secondary);
 	border-bottom: none;
+}
+
+.site-logo {
+	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+}
+
+.site-logo .custom-logo {
+	border-radius: var(--branding--logo--border-radius);
+	max-width: var(--branding--logo--max-width);
+	height: auto;
 }
 
 .main-navigation {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -827,7 +827,9 @@ body {
 }
 
 a {
+	border-bottom: 1px solid var(--global--color-secondary);
 	color: var(--global--color-primary);
+	text-decoration: none;
 }
 
 a:hover {
@@ -2804,11 +2806,6 @@ table th,
 	color: currentColor;
 	font-family: var(--branding--description--font-family);
 	font-size: var(--branding--description--font-size);
-}
-
-a {
-	text-decoration: none;
-	border-bottom: 1px solid var(--global--color-secondary);
 }
 
 a.custom-logo-link,

--- a/varya/style.css
+++ b/varya/style.css
@@ -2843,10 +2843,8 @@ nav a {
 }
 
 .site-title > a {
-	text-decoration: underline;
 	text-underline-width: .125em;
 	text-decoration-color: var(--global--color-secondary);
-	border-bottom: none;
 }
 
 .site-logo {

--- a/varya/style.css
+++ b/varya/style.css
@@ -195,6 +195,11 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	}
 }
 
+.site-header {
+	padding-top: calc(3 * var(--global--spacing-vertical));
+	padding-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
 /**
  * Site-main children wrappers
  * - Add double vertical margins here for clearer heirarchy
@@ -2795,6 +2800,7 @@ table th,
  */
 .site-branding {
 	color: var(--branding--color-text);
+	text-align: center;
 }
 
 .site-title {
@@ -2803,6 +2809,7 @@ table th,
 	font-size: var(--branding--title--font-size);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
+	margin-bottom: var(--global--spacing-vertical);
 }
 
 .site-title a {
@@ -2840,6 +2847,16 @@ nav a {
 	text-underline-width: .125em;
 	text-decoration-color: var(--global--color-secondary);
 	border-bottom: none;
+}
+
+.site-logo {
+	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+}
+
+.site-logo .custom-logo {
+	border-radius: var(--branding--logo--border-radius);
+	max-width: var(--branding--logo--max-width);
+	height: auto;
 }
 
 .main-navigation {


### PR DESCRIPTION
(This is based on #21, so that should get merged in first)

Adds a few quick styles to get the site header looking more like the comps: 

- Center-aligns the items in there.
- Adjust the vertical margins.
- Adds a circular mask to the site logo.
- Changes the font weight for the header to Bold. 
- Switches the underline approach to use borders. We'll want to make this a little cleaner, but this is decent for now. 

---

Before:

![Screen Shot 2020-03-30 at 12 45 29 PM](https://user-images.githubusercontent.com/1202812/77939003-8886b300-7284-11ea-8f70-8273106c1abd.png)

After:

![Screen Shot 2020-03-30 at 12 54 04 PM](https://user-images.githubusercontent.com/1202812/77939802-b3bdd200-7285-11ea-9a74-893ad7687096.png)

