### PR TITLE
Varya: Move main nav to the center on larger screens

### DIFF
--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -162,6 +162,7 @@
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
+	--primary-nav--justify-content: center;
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);
 	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -162,6 +162,7 @@
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
+	--primary-nav--justify-content: center;
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);
 	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -16,6 +16,7 @@
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
+	--primary-nav--justify-content: center;
 
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -2,10 +2,8 @@
 
 .main-navigation {
 
-	display: flex;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	justify-content: var(--primary-nav--justify-content);
 
 	// Menu wrapper
 	& > div {
@@ -44,6 +42,9 @@
 	}
 
 	@include media(mobile) {
+
+		display: flex;
+		justify-content: var(--primary-nav--justify-content);
 
 		& > div {
 			display: inline-block;

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -2,8 +2,10 @@
 
 .main-navigation {
 
+	display: flex;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
+	justify-content: var(--primary-nav--justify-content);
 
 	// Menu wrapper
 	& > div {

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -4,6 +4,7 @@
 
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
+	margin-top: var(--global--spacing-vertical);
 
 	// Menu wrapper
 	& > div {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2817,6 +2817,7 @@ nav a {
 .main-navigation {
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
+	margin-top: var(--global--spacing-vertical);
 }
 
 .main-navigation > div {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -822,7 +822,9 @@ body {
 }
 
 a {
+	border-bottom: 1px solid var(--global--color-secondary);
 	color: var(--global--color-primary);
+	text-decoration: none;
 }
 
 a:hover {
@@ -2799,11 +2801,6 @@ table th,
 	font-size: var(--branding--description--font-size);
 }
 
-a {
-	text-decoration: none;
-	border-bottom: 1px solid var(--global--color-secondary);
-}
-
 a.custom-logo-link,
 nav a {
 	border-bottom: none;
@@ -2818,8 +2815,10 @@ nav a {
 }
 
 .main-navigation {
+	display: flex;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
+	justify-content: var(--primary-nav--justify-content);
 }
 
 .main-navigation > div {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2815,10 +2815,8 @@ nav a {
 }
 
 .main-navigation {
-	display: flex;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	justify-content: var(--primary-nav--justify-content);
 }
 
 .main-navigation > div {
@@ -2853,6 +2851,10 @@ nav a {
 }
 
 @media only screen and (min-width: 560px) {
+	.main-navigation {
+		display: flex;
+		justify-content: var(--primary-nav--justify-content);
+	}
 	.main-navigation > div {
 		display: inline-block;
 	}

--- a/varya/style.css
+++ b/varya/style.css
@@ -2842,6 +2842,7 @@ nav a {
 .main-navigation {
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
+	margin-top: var(--global--spacing-vertical);
 }
 
 .main-navigation > div {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2840,10 +2840,8 @@ nav a {
 }
 
 .main-navigation {
-	display: flex;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	justify-content: var(--primary-nav--justify-content);
 }
 
 .main-navigation > div {
@@ -2878,6 +2876,10 @@ nav a {
 }
 
 @media only screen and (min-width: 560px) {
+	.main-navigation {
+		display: flex;
+		justify-content: var(--primary-nav--justify-content);
+	}
 	.main-navigation > div {
 		display: inline-block;
 	}

--- a/varya/style.css
+++ b/varya/style.css
@@ -2840,8 +2840,10 @@ nav a {
 }
 
 .main-navigation {
+	display: flex;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
+	justify-content: var(--primary-nav--justify-content);
 }
 
 .main-navigation > div {


### PR DESCRIPTION
This doesn't match the comps for now, but it gets things synced up with #26 until we can implement the other way. 

---

**Before**

<img width="799" alt="Screen Shot 2020-03-30 at 1 49 50 PM" src="https://user-images.githubusercontent.com/1202812/77944664-54fc5680-728d-11ea-8cb7-22d6a22182e6.png">

**After**

<img width="1073" alt="Screen Shot 2020-03-30 at 1 43 37 PM" src="https://user-images.githubusercontent.com/1202812/77944628-43b34a00-728d-11ea-9ba7-4f7b09b0d008.png">