### PR TITLE
[Varya] Rework max width for content blocks in the editor

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -1,6 +1,95 @@
 /**
  * These styles should be loaded by the Block Editor only
  */
+/**
+ * Repsonsive Styles
+ */
+/**
+ * Required Variables
+ */
+/**
+ * Root Media Query Variables
+ */
+:root {
+	--responsive--spacing-horizontal: calc(2 * var(--global--spacing-horizontal));
+	--responsive--aligndefault-width: 100%;
+	--responsive--alignwide-width: 100%;
+	--responsive--alignfull-width: 100%;
+	--responsive--aligndefault-width: 100%;
+	--responsive--alignwide-width-multiplier: calc(16 * var(--global--spacing-horizontal));
+	--responsive--alignright-margin: var(--global--spacing-horizontal);
+	--responsive--alignleft-margin: var(--global--spacing-horizontal);
+}
+
+@media only screen and (min-width: 560px) {
+	:root {
+		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+@media only screen and (min-width: 640px) {
+	:root {
+		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+@media only screen and (min-width: 782px) {
+	:root {
+		--responsive--aligndefault-width: calc(640px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(782px - var(--responsive--spacing-horizontal));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+@media only screen and (min-width: 1024px) {
+	:root {
+		--responsive--aligndefault-width: calc(782px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(782px + var(--responsive--alignwide-width-multiplier));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+@media only screen and (min-width: 1280px) {
+	:root {
+		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+/**
+ * Extends
+ */
+.default-max-width, .wp-block:not([data-align="full"]):not([data-align="wide"]) {
+	max-width: var(--responsive--aligndefault-width);
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.wide-max-width {
+	max-width: var(--responsive--alignwide-width);
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.full-max-width {
+	max-width: var(--responsive--alignfull-width);
+	margin-left: auto;
+	margin-right: auto;
+}
+
+/**
+ * Output
+ */
 body {
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
@@ -30,6 +119,10 @@ a:hover {
 button,
 a {
 	cursor: pointer;
+}
+
+div[data-type="core/button"] {
+	display: block;
 }
 
 /**

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -1,3 +1,5 @@
+@import '../structure/responsive-logic';
+
 body {
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
@@ -22,11 +24,23 @@ a {
 	color: var(--global--color-primary);
 
 	&:hover {
-		color: var(--global--color-primary-hover);;
+		color: var(--global--color-primary-hover);
 	}
 }
 
 button,
 a {
 	cursor: pointer;
+}
+
+// Gutenberg injects a rule that limits the max width of .wp-block to 580px
+// This line overrides it to use the responsive spacing rules for default width content 
+.wp-block {
+	&:not([data-align="full"]):not([data-align="wide"]){
+		@extend %responsive-aligndefault-width;
+	}
+}
+
+div[data-type="core/button"] {
+	display: block;
 }


### PR DESCRIPTION
Gutenberg injects a style rule that limits the max-width of blocks that are not align full or align wide to 580px: https://github.com/WordPress/gutenberg/blob/34253056f822cf554437d5ad449b033d811e199f/packages/edit-post/src/style.scss#L104

This causes inconsistency between the front-end and editor in this theme.

This PR leverages the responsive rules developed for the front end into the editor to set the default content width of blocks that are not align full or align wide. 

**Before**
<img width="1066" alt="Screen Shot 2020-03-31 at 5 54 06 PM" src="https://user-images.githubusercontent.com/5375500/78079180-979b5d00-7379-11ea-947c-0880630ff171.png">

**After**
<img width="1069" alt="Screen Shot 2020-03-31 at 5 53 43 PM" src="https://user-images.githubusercontent.com/5375500/78079272-c580a180-7379-11ea-95b7-a63218a6801e.png">

If this approach is acceptable, then we should probably revisit how we implement the align wide responsive styles in the editor.