### PR TITLE
Varya: Clean up responsive logic

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -15,34 +15,42 @@
 	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width: 100%;
 	--responsive--alignfull-width: 100%;
-	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width-multiplier: calc(16 * var(--global--spacing-horizontal));
 	--responsive--alignright-margin: var(--global--spacing-horizontal);
 	--responsive--alignleft-margin: var(--global--spacing-horizontal);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(482px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(592px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 782px) {
+@media only screen and (min-width: 652px) {
 	:root {
-		--responsive--aligndefault-width: calc(640px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(592px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+@media only screen and (min-width: 822px) {
+	:root {
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -50,17 +58,8 @@
 
 @media only screen and (min-width: 1024px) {
 	:root {
-		--responsive--aligndefault-width: calc(782px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px + var(--responsive--alignwide-width-multiplier));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-@media only screen and (min-width: 1280px) {
-	:root {
-		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -16,34 +16,42 @@
 	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width: 100%;
 	--responsive--alignfull-width: 100%;
-	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width-multiplier: calc(16 * var(--global--spacing-horizontal));
 	--responsive--alignright-margin: var(--global--spacing-horizontal);
 	--responsive--alignleft-margin: var(--global--spacing-horizontal);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(482px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(592px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 782px) {
+@media only screen and (min-width: 652px) {
 	:root {
-		--responsive--aligndefault-width: calc(640px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(592px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+@media only screen and (min-width: 822px) {
+	:root {
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -51,17 +59,8 @@
 
 @media only screen and (min-width: 1024px) {
 	:root {
-		--responsive--aligndefault-width: calc(782px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px + var(--responsive--alignwide-width-multiplier));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-@media only screen and (min-width: 1280px) {
-	:root {
-		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -118,7 +117,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-left: auto;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.site-header,
 	.site-main,
 	.site-footer {
@@ -190,7 +189,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.site-footer > *,
 	.site-main > article > *,
 	.site-main > .not-found > *,
@@ -895,7 +894,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	display: inline;
 }
 
-@media only screen and (max-width: 559px) {
+@media only screen and (max-width: 481px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);
 		color: var(--wc--mini-cart--color-text);
@@ -909,7 +908,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	}
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation > div:not(:last-of-type) {
 		margin-left: calc(2 * var(--global--spacing-unit));
 	}
@@ -944,7 +943,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 	vertical-align: middle;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link {
 		display: inline-block;
 	}
@@ -957,7 +956,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 	padding: var(--primary-nav--padding) 0;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 		max-width: calc(20 * var(--global--spacing-horizontal));
 		padding: var(--primary-nav--padding);
@@ -1039,7 +1038,7 @@ body[class*="woocommerce"] #page .main-navigation ul.product_list_widget li .qua
 	font-size: var(--global--font-size-base);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation > div > ul > li.woocommerce-menu-item > .sub-menu {
 		right: auto;
 		left: 0;
@@ -1621,7 +1620,7 @@ body[class*="woocommerce"] #page table.shop_table td.product-remove {
 	border-width: 0;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	body[class*="woocommerce"] #page table.shop_table td.product-remove {
 		height: var(--global--font-size-sm);
 		width: var(--global--font-size-sm);
@@ -1906,7 +1905,7 @@ body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigatio
 	margin-top: 0;
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigation {
 		width: 20%;
 	}
@@ -1926,7 +1925,7 @@ body[class*="woocommerce"] #page .woocommerce-MyAccount-content fieldset {
 	border-radius: 3px;
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	body[class*="woocommerce"] #page .woocommerce-MyAccount-content {
 		width: calc(80% - var(--global--spacing-horizontal));
 	}
@@ -2202,7 +2201,7 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 /**
  * Filter by Product List Widgets
  */
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .widget.woocommerce ul.product_list_widget:not(.woocommerce-mini-cart) {
 		display: flex;
 		flex-wrap: wrap;

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -16,34 +16,42 @@
 	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width: 100%;
 	--responsive--alignfull-width: 100%;
-	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width-multiplier: calc(16 * var(--global--spacing-horizontal));
 	--responsive--alignright-margin: var(--global--spacing-horizontal);
 	--responsive--alignleft-margin: var(--global--spacing-horizontal);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(482px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(592px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 782px) {
+@media only screen and (min-width: 652px) {
 	:root {
-		--responsive--aligndefault-width: calc(640px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(592px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+@media only screen and (min-width: 822px) {
+	:root {
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -51,17 +59,8 @@
 
 @media only screen and (min-width: 1024px) {
 	:root {
-		--responsive--aligndefault-width: calc(782px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px + var(--responsive--alignwide-width-multiplier));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-@media only screen and (min-width: 1280px) {
-	:root {
-		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -118,7 +117,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.site-header,
 	.site-main,
 	.site-footer {
@@ -190,7 +189,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.site-footer > *,
 	.site-main > article > *,
 	.site-main > .not-found > *,
@@ -895,7 +894,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	display: inline;
 }
 
-@media only screen and (max-width: 559px) {
+@media only screen and (max-width: 481px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);
 		color: var(--wc--mini-cart--color-text);
@@ -909,7 +908,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	}
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation > div:not(:last-of-type) {
 		margin-right: calc(2 * var(--global--spacing-unit));
 	}
@@ -944,7 +943,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 	vertical-align: middle;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link {
 		display: inline-block;
 	}
@@ -957,7 +956,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 	padding: var(--primary-nav--padding) 0;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 		max-width: calc(20 * var(--global--spacing-horizontal));
 		padding: var(--primary-nav--padding);
@@ -1039,7 +1038,7 @@ body[class*="woocommerce"] #page .main-navigation ul.product_list_widget li .qua
 	font-size: var(--global--font-size-base);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation > div > ul > li.woocommerce-menu-item > .sub-menu {
 		left: auto;
 		right: 0;
@@ -1621,7 +1620,7 @@ body[class*="woocommerce"] #page table.shop_table td.product-remove {
 	border-width: 0;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	body[class*="woocommerce"] #page table.shop_table td.product-remove {
 		height: var(--global--font-size-sm);
 		width: var(--global--font-size-sm);
@@ -1906,7 +1905,7 @@ body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigatio
 	margin-top: 0;
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigation {
 		width: 20%;
 	}
@@ -1926,7 +1925,7 @@ body[class*="woocommerce"] #page .woocommerce-MyAccount-content fieldset {
 	border-radius: 3px;
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	body[class*="woocommerce"] #page .woocommerce-MyAccount-content {
 		width: calc(80% - var(--global--spacing-horizontal));
 	}
@@ -2202,7 +2201,7 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 /**
  * Filter by Product List Widgets
  */
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .widget.woocommerce ul.product_list_widget:not(.woocommerce-mini-cart) {
 		display: flex;
 		flex-wrap: wrap;

--- a/varya/assets/sass/structure/_responsive-logic.scss
+++ b/varya/assets/sass/structure/_responsive-logic.scss
@@ -8,59 +8,71 @@
 $flexwidth: 100%;
 $horizontal_space: var(--global--spacing-horizontal);
 
-$breakpoint_sm: 560px;
-$breakpoint_md: 640px;
-$breakpoint_lg: 782px;
-$breakpoint_xl: 1024px;
-$breakpoint_xxl: 1280px;
-
-@custom-media --sm only screen and (min-width: #{$breakpoint_sm});
-@custom-media --md only screen and (min-width: #{$breakpoint_md});
-@custom-media --lg only screen and (min-width: #{$breakpoint_lg});
-@custom-media --xl only screen and (min-width: #{$breakpoint_xl});
-@custom-media --xxl only screen and (min-width: #{$breakpoint_xxl});
-
-@custom-media --sm-max only screen and (max-width: #{$breakpoint_sm - 1});
-@custom-media --md-max only screen and (max-width: #{$breakpoint_md - 1});
-@custom-media --lg-max only screen and (max-width: #{$breakpoint_lg - 1});
-@custom-media --xl-max only screen and (max-width: #{$breakpoint_xl - 1});
-@custom-media --xxl-max only screen and (max-width: #{$breakpoint_xxl - 1});
+$breakpoint_sm: 482px;
+$breakpoint_md: 592px;
+$breakpoint_lg: 652px;
+$breakpoint_xl: 822px;
+$breakpoint_xxl: 1024px;
 
 // Responsive breakpoints mixin
 @mixin media( $res ) {
 
 	@if mobile-only == $res {
-		@media (--sm-max) {
+		@media only screen and (max-width: #{$breakpoint_sm - 1}) {
 			@content;
 		}
 	}
 
 	@if mobile == $res {
-		@media (--sm) {
+		@media only screen and (min-width: #{$breakpoint_sm}) {
+			@content;
+		}
+	}
+
+	@if tablet-only == $res {
+		@media only screen and (max-width: #{$breakpoint_md - 1}) {
 			@content;
 		}
 	}
 
 	@if tablet == $res {
-		@media (--md) {
+		@media only screen and (min-width: #{$breakpoint_md}) {
+			@content;
+		}
+	}
+
+	@if laptop-only == $res {
+		@media only screen and (max-width: #{$breakpoint_lg - 1}) {
 			@content;
 		}
 	}
 
 	@if laptop == $res {
-		@media (--lg) {
+		@media only screen and (min-width: #{$breakpoint_lg}) {
+			@content;
+		}
+	}
+
+	@if desktop-only == $res {
+		@media only screen and (max-width: #{$breakpoint_xl - 1}) {
 			@content;
 		}
 	}
 
 	@if desktop == $res {
-		@media (--xl) {
+		@media only screen and (min-width: #{$breakpoint_xl}) {
+			@content;
+		}
+	}
+
+	@if wide-only == $res {
+		@media only screen and (max-width: #{$breakpoint_xxl - 1}) {
 			@content;
 		}
 	}
 
 	@if wide == $res {
-		@media (--xxl) {
+		@media only screen and (min-width: #{$breakpoint_xxl}) {
 			@content;
 		}
 	}
@@ -74,7 +86,6 @@ $breakpoint_xxl: 1280px;
 	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width: 100%;
 	--responsive--alignfull-width: 100%;
-	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width-multiplier: calc(16 * var(--global--spacing-horizontal));
 	--responsive--alignright-margin: var(--global--spacing-horizontal);
 	--responsive--alignleft-margin: var(--global--spacing-horizontal);
@@ -92,7 +103,7 @@ $breakpoint_xxl: 1280px;
 @include media(tablet) {
 	:root {
 		--responsive--aligndefault-width: calc(#{$breakpoint_sm} - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(#{$breakpoint_sm} - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(#{$breakpoint_md} - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -110,7 +121,7 @@ $breakpoint_xxl: 1280px;
 @include media(desktop) {
 	:root {
 		--responsive--aligndefault-width: calc(#{$breakpoint_lg} - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(#{$breakpoint_lg} + var(--responsive--alignwide-width-multiplier));
+		--responsive--alignwide-width: calc(#{$breakpoint_xl} - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -118,8 +129,8 @@ $breakpoint_xxl: 1280px;
 
 @include media(wide) {
 	:root {
-		--responsive--aligndefault-width: calc(#{$breakpoint_xl} - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(#{$breakpoint_xl} + var(--responsive--alignwide-width-multiplier));
+		--responsive--aligndefault-width: calc(#{$breakpoint_lg} - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(#{$breakpoint_xl} - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -39,34 +39,42 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width: 100%;
 	--responsive--alignfull-width: 100%;
-	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width-multiplier: calc(16 * var(--global--spacing-horizontal));
 	--responsive--alignright-margin: var(--global--spacing-horizontal);
 	--responsive--alignleft-margin: var(--global--spacing-horizontal);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(482px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(592px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 782px) {
+@media only screen and (min-width: 652px) {
 	:root {
-		--responsive--aligndefault-width: calc(640px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(592px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+@media only screen and (min-width: 822px) {
+	:root {
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -74,17 +82,8 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
 @media only screen and (min-width: 1024px) {
 	:root {
-		--responsive--aligndefault-width: calc(782px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px + var(--responsive--alignwide-width-multiplier));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-@media only screen and (min-width: 1280px) {
-	:root {
-		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -134,7 +133,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-right: var(--responsive--spacing-horizontal);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.entry-content .wp-block-button.alignright, .entry-content > .alignleft {
 		margin-left: auto;
 		margin-right: var(--responsive--alignleft-margin);
@@ -146,7 +145,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-right: 0;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.entry-content .wp-block-button.alignleft, .entry-content > .alignright {
 		margin-left: var(--responsive--alignright-margin);
 		margin-right: auto;
@@ -176,7 +175,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-left: auto;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.site-header,
 	.site-main,
 	.site-footer {
@@ -248,7 +247,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.site-footer > *,
 	.site-main > article > *,
 	.site-main > .not-found > *,
@@ -811,7 +810,7 @@ html {
 	line-height: var(--global--line-height-body);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	html {
 		font-size: var(--global--font-size-root);
 	}
@@ -1104,7 +1103,7 @@ object {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-newspack-blocks-homepage-articles.is-grid article {
 		margin-bottom: calc(3 * var(--global--spacing-vertical));
 	}
@@ -1126,7 +1125,7 @@ object {
 	margin-bottom: calc(2 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-newspack-blocks-homepage-articles article {
 		margin-top: calc(3 * var(--global--spacing-vertical));
 		margin-bottom: calc(3 * var(--global--spacing-vertical));
@@ -1180,7 +1179,7 @@ object {
 	color: currentColor;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-newspack-blocks-homepage-articles article .more-link {
 		margin-top: var(--global--spacing-unit);
 	}
@@ -1529,7 +1528,7 @@ button[data-load-more-btn],
 	margin-bottom: calc(0.66 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-columns .wp-block-column > * {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
@@ -1552,13 +1551,13 @@ button[data-load-more-btn],
 	margin-bottom: calc(0.66 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-columns .wp-block-column:not(:last-child) {
 		margin-bottom: var(--global--spacing-vertical);
 	}
 }
 
-@media only screen and (min-width: 782px) {
+@media only screen and (min-width: 652px) {
 	.wp-block-columns .wp-block-column:not(:last-child) {
 		/* Resetting margins to match _block-container.scss */
 		margin-bottom: 0;
@@ -1648,7 +1647,7 @@ button[data-load-more-btn],
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-cover .wp-block-cover__inner-container > *,
 	.wp-block-cover-image .wp-block-cover__inner-container > * {
 		margin-top: var(--global--spacing-vertical);
@@ -1739,7 +1738,7 @@ button[data-load-more-btn],
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-group .wp-block-group__inner-container > * {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
@@ -1758,7 +1757,7 @@ button[data-load-more-btn],
 	padding: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-group.has-background {
 		padding: var(--global--spacing-vertical);
 	}
@@ -2075,7 +2074,7 @@ dd {
 	padding: var(--global--spacing-horizontal);
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	.wp-block-media-text .wp-block-media-text__content {
 		padding: var(--global--spacing-vertical);
 	}
@@ -2086,7 +2085,7 @@ dd {
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-media-text .wp-block-media-text__content > * {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
@@ -2105,7 +2104,7 @@ dd {
 	color: currentColor;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__content {
 		padding-top: var(--global--spacing-vertical);
 		padding-bottom: var(--global--spacing-vertical);
@@ -2404,7 +2403,7 @@ hr.wp-block-separator.is-style-dots:before {
 	margin-top: 0 !important;
 }
 
-@media only screen and (max-width: 559px) {
+@media only screen and (max-width: 481px) {
 	.wp-block-spacer[style] {
 		height: var(--global--spacing-unit) !important;
 	}
@@ -2660,7 +2659,7 @@ table th,
 	display: none;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.desktop-only {
 		display: block;
 	}
@@ -2866,7 +2865,7 @@ nav a {
 	display: inline;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation {
 		display: flex;
 		justify-content: var(--primary-nav--justify-content);
@@ -2909,7 +2908,7 @@ nav a {
 	z-index: 99999;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation > div > ul li {
 		display: inherit;
 		width: inherit;
@@ -2925,7 +2924,7 @@ nav a {
 	}
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > li > a {
 		line-height: var(--global--line-height-base);
 	}
@@ -2954,7 +2953,7 @@ nav a {
 	position: relative;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > li > .sub-menu {
 		background: var(--global--color-background);
 		box-shadow: var(--global--elevation-4);
@@ -2980,7 +2979,7 @@ nav a {
 	padding: calc(0.5 * var(--primary-nav--padding)) 0;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation a {
 		padding: var(--primary-nav--padding);
 	}
@@ -3013,7 +3012,7 @@ nav a {
 	content: "– " counters(nested-list, "– ", none);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > .menu-item-has-children > a::after {
 		content: "\00a0\25BC";
 		display: inline-block;
@@ -3068,7 +3067,7 @@ nav a {
 	overflow: hidden;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	.site-footer {
 		align-items: flex-end;
 		display: flex;
@@ -3084,7 +3083,7 @@ nav a {
 	line-height: var(--global--line-height-body);
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	.site-footer > .site-info {
 		order: 1;
 		flex: 1 0 50%;
@@ -3113,7 +3112,7 @@ nav a {
 	display: inline;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	.site-footer > .footer-navigation {
 		flex: 1 0 50%;
 		order: 2;
@@ -3133,7 +3132,7 @@ nav a {
 	padding-right: 0;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	.site-footer > .footer-navigation .footer-menu {
 		display: flex;
 		flex-wrap: wrap;
@@ -3205,7 +3204,7 @@ nav a {
 	margin-top: var(--global--spacing-unit);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.entry-content .more-link {
 		margin-top: var(--global--spacing-vertical);
 	}
@@ -3226,7 +3225,7 @@ nav a {
 	max-width: 100% !important;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.entry-content > iframe[style] {
 		max-width: var(--global--spacing-vertical) !important;
 	}
@@ -3327,7 +3326,7 @@ nav a {
 	color: var(--global--color-primary-hover);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.navigation .nav-links {
 		display: flex;
 		justify-content: center;
@@ -3362,7 +3361,7 @@ nav a {
 	font-weight: 600;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.post-navigation .nav-links {
 		justify-content: space-between;
 	}
@@ -3472,7 +3471,7 @@ nav a {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-list .children {
 		padding-right: calc(2 * var(--global--spacing-horizontal));
 	}
@@ -3492,7 +3491,7 @@ nav a {
 	max-width: calc(100% - (3 * var(--global--spacing-horizontal)));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-meta .comment-author {
 		display: flex;
 		align-items: center;
@@ -3518,7 +3517,7 @@ nav a {
 	padding-left: calc(2.5 * var(--global--spacing-horizontal));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-meta .comment-metadata {
 		padding-left: 0;
 	}
@@ -3532,7 +3531,7 @@ nav a {
 	color: var(--global--color-primary-hover);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-meta {
 		margin-left: inherit;
 		align-items: center;
@@ -3569,7 +3568,7 @@ nav a {
 	text-align: left;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.reply {
 		text-align: right;
 	}
@@ -3650,7 +3649,7 @@ nav a {
 	width: auto;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-form > p {
 		display: flex;
 	}
@@ -4170,7 +4169,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	display: inline;
 }
 
-@media only screen and (max-width: 559px) {
+@media only screen and (max-width: 481px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);
 		color: var(--wc--mini-cart--color-text);
@@ -4184,7 +4183,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	}
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation > div:not(:last-of-type) {
 		margin-left: calc(2 * var(--global--spacing-unit));
 	}
@@ -4219,7 +4218,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 	vertical-align: middle;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link {
 		display: inline-block;
 	}
@@ -4232,7 +4231,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 	padding: var(--primary-nav--padding) 0;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 		max-width: calc(20 * var(--global--spacing-horizontal));
 		padding: var(--primary-nav--padding);
@@ -4314,7 +4313,7 @@ body[class*="woocommerce"] #page .main-navigation ul.product_list_widget li .qua
 	font-size: var(--global--font-size-base);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation > div > ul > li.woocommerce-menu-item > .sub-menu {
 		right: auto;
 		left: 0;
@@ -4896,7 +4895,7 @@ body[class*="woocommerce"] #page table.shop_table td.product-remove {
 	border-width: 0;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	body[class*="woocommerce"] #page table.shop_table td.product-remove {
 		height: var(--global--font-size-sm);
 		width: var(--global--font-size-sm);
@@ -5181,7 +5180,7 @@ body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigatio
 	margin-top: 0;
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigation {
 		width: 20%;
 	}
@@ -5201,7 +5200,7 @@ body[class*="woocommerce"] #page .woocommerce-MyAccount-content fieldset {
 	border-radius: 3px;
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	body[class*="woocommerce"] #page .woocommerce-MyAccount-content {
 		width: calc(80% - var(--global--spacing-horizontal));
 	}
@@ -5477,7 +5476,7 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 /**
  * Filter by Product List Widgets
  */
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .widget.woocommerce ul.product_list_widget:not(.woocommerce-mini-cart) {
 		display: flex;
 		flex-wrap: wrap;

--- a/varya/style.css
+++ b/varya/style.css
@@ -39,34 +39,42 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width: 100%;
 	--responsive--alignfull-width: 100%;
-	--responsive--aligndefault-width: 100%;
 	--responsive--alignwide-width-multiplier: calc(16 * var(--global--spacing-horizontal));
 	--responsive--alignright-margin: var(--global--spacing-horizontal);
 	--responsive--alignleft-margin: var(--global--spacing-horizontal);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(482px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	:root {
-		--responsive--aligndefault-width: calc(560px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(560px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(482px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(592px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
 }
 
-@media only screen and (min-width: 782px) {
+@media only screen and (min-width: 652px) {
 	:root {
-		--responsive--aligndefault-width: calc(640px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px - var(--responsive--spacing-horizontal));
+		--responsive--aligndefault-width: calc(592px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+
+@media only screen and (min-width: 822px) {
+	:root {
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -74,17 +82,8 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
 @media only screen and (min-width: 1024px) {
 	:root {
-		--responsive--aligndefault-width: calc(782px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(782px + var(--responsive--alignwide-width-multiplier));
-		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
-	}
-}
-
-@media only screen and (min-width: 1280px) {
-	:root {
-		--responsive--aligndefault-width: calc(1024px - var(--responsive--spacing-horizontal));
-		--responsive--alignwide-width: calc(1024px + var(--responsive--alignwide-width-multiplier));
+		--responsive--aligndefault-width: calc(652px - var(--responsive--spacing-horizontal));
+		--responsive--alignwide-width: calc(822px - var(--responsive--spacing-horizontal));
 		--responsive--alignright-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 		--responsive--alignleft-margin: calc( 0.5 * (100vw - var(--responsive--aligndefault-width)));
 	}
@@ -136,7 +135,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-right: var(--responsive--spacing-horizontal);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.entry-content .wp-block-button.alignright, .entry-content > .alignleft {
 		/*rtl:ignore*/
 		margin-left: auto;
@@ -152,7 +151,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-right: 0;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.entry-content .wp-block-button.alignleft, .entry-content > .alignright {
 		/*rtl:ignore*/
 		margin-left: var(--responsive--alignright-margin);
@@ -184,7 +183,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-right: auto;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.site-header,
 	.site-main,
 	.site-footer {
@@ -256,7 +255,7 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.site-footer > *,
 	.site-main > article > *,
 	.site-main > .not-found > *,
@@ -819,7 +818,7 @@ html {
 	line-height: var(--global--line-height-body);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	html {
 		font-size: var(--global--font-size-root);
 	}
@@ -1112,7 +1111,7 @@ object {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-newspack-blocks-homepage-articles.is-grid article {
 		margin-bottom: calc(3 * var(--global--spacing-vertical));
 	}
@@ -1134,7 +1133,7 @@ object {
 	margin-bottom: calc(2 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-newspack-blocks-homepage-articles article {
 		margin-top: calc(3 * var(--global--spacing-vertical));
 		margin-bottom: calc(3 * var(--global--spacing-vertical));
@@ -1188,7 +1187,7 @@ object {
 	color: currentColor;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-newspack-blocks-homepage-articles article .more-link {
 		margin-top: var(--global--spacing-unit);
 	}
@@ -1537,7 +1536,7 @@ button[data-load-more-btn],
 	margin-bottom: calc(0.66 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-columns .wp-block-column > * {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
@@ -1560,13 +1559,13 @@ button[data-load-more-btn],
 	margin-bottom: calc(0.66 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-columns .wp-block-column:not(:last-child) {
 		margin-bottom: var(--global--spacing-vertical);
 	}
 }
 
-@media only screen and (min-width: 782px) {
+@media only screen and (min-width: 652px) {
 	.wp-block-columns .wp-block-column:not(:last-child) {
 		/* Resetting margins to match _block-container.scss */
 		margin-bottom: 0;
@@ -1656,7 +1655,7 @@ button[data-load-more-btn],
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-cover .wp-block-cover__inner-container > *,
 	.wp-block-cover-image .wp-block-cover__inner-container > * {
 		margin-top: var(--global--spacing-vertical);
@@ -1747,7 +1746,7 @@ button[data-load-more-btn],
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-group .wp-block-group__inner-container > * {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
@@ -1766,7 +1765,7 @@ button[data-load-more-btn],
 	padding: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-group.has-background {
 		padding: var(--global--spacing-vertical);
 	}
@@ -2083,7 +2082,7 @@ dd {
 	padding: var(--global--spacing-horizontal);
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	.wp-block-media-text .wp-block-media-text__content {
 		padding: var(--global--spacing-vertical);
 	}
@@ -2094,7 +2093,7 @@ dd {
 	margin-bottom: calc( 0.666 * var(--global--spacing-vertical));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-media-text .wp-block-media-text__content > * {
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
@@ -2113,7 +2112,7 @@ dd {
 	color: currentColor;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__content {
 		padding-top: var(--global--spacing-vertical);
 		padding-bottom: var(--global--spacing-vertical);
@@ -2412,7 +2411,7 @@ hr.wp-block-separator.is-style-dots:before {
 	margin-top: 0 !important;
 }
 
-@media only screen and (max-width: 559px) {
+@media only screen and (max-width: 481px) {
 	.wp-block-spacer[style] {
 		height: var(--global--spacing-unit) !important;
 	}
@@ -2673,7 +2672,7 @@ table th,
 	display: none;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.desktop-only {
 		display: block;
 	}
@@ -2891,7 +2890,7 @@ nav a {
 	display: inline;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation {
 		display: flex;
 		justify-content: var(--primary-nav--justify-content);
@@ -2934,7 +2933,7 @@ nav a {
 	z-index: 99999;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation > div > ul li {
 		display: inherit;
 		width: inherit;
@@ -2950,7 +2949,7 @@ nav a {
 	}
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > li > a {
 		line-height: var(--global--line-height-base);
 	}
@@ -2979,7 +2978,7 @@ nav a {
 	position: relative;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > li > .sub-menu {
 		background: var(--global--color-background);
 		box-shadow: var(--global--elevation-4);
@@ -3005,7 +3004,7 @@ nav a {
 	padding: calc(0.5 * var(--primary-nav--padding)) 0;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation a {
 		padding: var(--primary-nav--padding);
 	}
@@ -3038,7 +3037,7 @@ nav a {
 	content: "– " counters(nested-list, "– ", none);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > .menu-item-has-children > a::after {
 		content: "\00a0\25BC";
 		display: inline-block;
@@ -3093,7 +3092,7 @@ nav a {
 	overflow: hidden;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	.site-footer {
 		align-items: flex-end;
 		display: flex;
@@ -3109,7 +3108,7 @@ nav a {
 	line-height: var(--global--line-height-body);
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	.site-footer > .site-info {
 		order: 1;
 		flex: 1 0 50%;
@@ -3138,7 +3137,7 @@ nav a {
 	display: inline;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	.site-footer > .footer-navigation {
 		flex: 1 0 50%;
 		order: 2;
@@ -3158,7 +3157,7 @@ nav a {
 	padding-left: 0;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	.site-footer > .footer-navigation .footer-menu {
 		display: flex;
 		flex-wrap: wrap;
@@ -3230,7 +3229,7 @@ nav a {
 	margin-top: var(--global--spacing-unit);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.entry-content .more-link {
 		margin-top: var(--global--spacing-vertical);
 	}
@@ -3251,7 +3250,7 @@ nav a {
 	max-width: 100% !important;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.entry-content > iframe[style] {
 		max-width: var(--global--spacing-vertical) !important;
 	}
@@ -3352,7 +3351,7 @@ nav a {
 	color: var(--global--color-primary-hover);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.navigation .nav-links {
 		display: flex;
 		justify-content: center;
@@ -3387,7 +3386,7 @@ nav a {
 	font-weight: 600;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.post-navigation .nav-links {
 		justify-content: space-between;
 	}
@@ -3497,7 +3496,7 @@ nav a {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-list .children {
 		padding-left: calc(2 * var(--global--spacing-horizontal));
 	}
@@ -3517,7 +3516,7 @@ nav a {
 	max-width: calc(100% - (3 * var(--global--spacing-horizontal)));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-meta .comment-author {
 		display: flex;
 		align-items: center;
@@ -3543,7 +3542,7 @@ nav a {
 	padding-right: calc(2.5 * var(--global--spacing-horizontal));
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-meta .comment-metadata {
 		padding-right: 0;
 	}
@@ -3557,7 +3556,7 @@ nav a {
 	color: var(--global--color-primary-hover);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-meta {
 		margin-right: inherit;
 		align-items: center;
@@ -3594,7 +3593,7 @@ nav a {
 	text-align: right;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.reply {
 		text-align: left;
 	}
@@ -3675,7 +3674,7 @@ nav a {
 	width: auto;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	.comment-form > p {
 		display: flex;
 	}
@@ -4195,7 +4194,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	display: inline;
 }
 
-@media only screen and (max-width: 559px) {
+@media only screen and (max-width: 481px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);
 		color: var(--wc--mini-cart--color-text);
@@ -4209,7 +4208,7 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 	}
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation > div:not(:last-of-type) {
 		margin-right: calc(2 * var(--global--spacing-unit));
 	}
@@ -4244,7 +4243,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 	vertical-align: middle;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link {
 		display: inline-block;
 	}
@@ -4257,7 +4256,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 	padding: var(--primary-nav--padding) 0;
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
 		max-width: calc(20 * var(--global--spacing-horizontal));
 		padding: var(--primary-nav--padding);
@@ -4339,7 +4338,7 @@ body[class*="woocommerce"] #page .main-navigation ul.product_list_widget li .qua
 	font-size: var(--global--font-size-base);
 }
 
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation > div > ul > li.woocommerce-menu-item > .sub-menu {
 		left: auto;
 		right: 0;
@@ -4921,7 +4920,7 @@ body[class*="woocommerce"] #page table.shop_table td.product-remove {
 	border-width: 0;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 822px) {
 	body[class*="woocommerce"] #page table.shop_table td.product-remove {
 		height: var(--global--font-size-sm);
 		width: var(--global--font-size-sm);
@@ -5206,7 +5205,7 @@ body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigatio
 	margin-top: 0;
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	body[class*="woocommerce"] #page .entry-content .woocommerce-MyAccount-navigation {
 		width: 20%;
 	}
@@ -5226,7 +5225,7 @@ body[class*="woocommerce"] #page .woocommerce-MyAccount-content fieldset {
 	border-radius: 3px;
 }
 
-@media only screen and (min-width: 640px) {
+@media only screen and (min-width: 592px) {
 	body[class*="woocommerce"] #page .woocommerce-MyAccount-content {
 		width: calc(80% - var(--global--spacing-horizontal));
 	}
@@ -5502,7 +5501,7 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 /**
  * Filter by Product List Widgets
  */
-@media only screen and (min-width: 560px) {
+@media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .widget.woocommerce ul.product_list_widget:not(.woocommerce-mini-cart) {
 		display: flex;
 		flex-wrap: wrap;


### PR DESCRIPTION
This PR revises the responsive logic to do the following:

- Remove CSS-variable based media queries in favor or normal media queries
- Remove duplicate CSS-variables
- Fix errors and typos in responsive width rules

Before | After
------------|------------
![image](https://user-images.githubusercontent.com/709581/78163589-99ffc480-7416-11ea-894b-5757cde3049c.png)|![image](https://user-images.githubusercontent.com/709581/78163457-6a50bc80-7416-11ea-8d62-582a7dabd2fc.png)

Fixes: #36