### PR TITLE
Varya: Remove subnav character indents and replace with more straightforward spacing.

### DIFF
--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -173,21 +173,12 @@
 	.sub-menu {
 
 		list-style: none;
-		margin-left: 0;
-		/* Reset the counter for each UL */
-		counter-reset: nested-list;
+		margin-left: var(--primary-nav--padding);
 
 		.menu-item a {
 
 			padding-top: calc(0.5 * var(--primary-nav--padding));
 			padding-bottom: calc(0.5 * var(--primary-nav--padding));
-
-			&::before {
-				/* Increment the dashes */
-				counter-increment: nested-list;
-				/* Insert dashes with spaces in between */
-				content: "\2013\00a0" counters( nested-list, "\2013\00a0", none );
-			}
 		}
 	}
 

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /*
 Theme Name: Varya
 Theme URI: https://github.com/Automattic/theme-workspace/varya
@@ -2995,21 +2994,12 @@ nav a {
 
 .main-navigation .sub-menu {
 	list-style: none;
-	margin-right: 0;
-	/* Reset the counter for each UL */
-	counter-reset: nested-list;
+	margin-right: --primary-nav--padding;
 }
 
 .main-navigation .sub-menu .menu-item a {
 	padding-top: calc(0.5 * var(--primary-nav--padding));
 	padding-bottom: calc(0.5 * var(--primary-nav--padding));
-}
-
-.main-navigation .sub-menu .menu-item a::before {
-	/* Increment the dashes */
-	counter-increment: nested-list;
-	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
 }
 
 @media only screen and (min-width: 482px) {

--- a/varya/style.css
+++ b/varya/style.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /*
 Theme Name: Varya
 Theme URI: https://github.com/Automattic/theme-workspace/varya
@@ -3020,21 +3019,12 @@ nav a {
 
 .main-navigation .sub-menu {
 	list-style: none;
-	margin-left: 0;
-	/* Reset the counter for each UL */
-	counter-reset: nested-list;
+	margin-left: var(--primary-nav--padding);
 }
 
 .main-navigation .sub-menu .menu-item a {
 	padding-top: calc(0.5 * var(--primary-nav--padding));
 	padding-bottom: calc(0.5 * var(--primary-nav--padding));
-}
-
-.main-navigation .sub-menu .menu-item a::before {
-	/* Increment the dashes */
-	counter-increment: nested-list;
-	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
 }
 
 @media only screen and (min-width: 482px) {


### PR DESCRIPTION
This removes the "-" indents for subnav items, and replaces it with some standard empty indents. Aside from just its use in this theme, using empty space seems like a more usual default scenario anyway. 

Before:

![Screen Shot 2020-04-01 at 2 11 25 PM](https://user-images.githubusercontent.com/1202812/78171597-b0138200-7422-11ea-9efb-95f006214bc2.png)

After: 

![Screen Shot 2020-04-01 at 2 08 14 PM](https://user-images.githubusercontent.com/1202812/78171549-9b36ee80-7422-11ea-87f8-a45c710101fd.png)
