### PR TITLE
Varya: Update dropdown arrows to match comps

### DIFF
--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -196,11 +196,17 @@
 		& > div > ul > .menu-item-has-children > a {
 
 			&::after {
-				content: "\00a0\25BC";
-				display: inline-block;
-				font-size: var(--global--font-size-xs);
+				content: "";
+				position: relative;
+				top: calc( var(--primary-nav--padding) / -4 );
 				height: inherit;
 				width: inherit;
+				border: solid currentColor;
+				border-width: 0 1px 1px 0;
+				display: inline-block;
+				margin-left: calc( var(--primary-nav--padding) / 2 );
+				padding: 3px;
+				transform: rotate(45deg);
 			}
 		}
 	}

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3014,11 +3014,17 @@ nav a {
 
 @media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > .menu-item-has-children > a::after {
-		content: "\00a0\25BC";
-		display: inline-block;
-		font-size: var(--global--font-size-xs);
+		content: "";
+		position: relative;
+		top: calc( var(--primary-nav--padding) / -4);
 		height: inherit;
 		width: inherit;
+		border: solid currentColor;
+		border-width: 0 0 1px 1px;
+		display: inline-block;
+		margin-right: calc( var(--primary-nav--padding) / 2);
+		padding: 3px;
+		transform: rotate(-45deg);
 	}
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -3039,11 +3039,17 @@ nav a {
 
 @media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > .menu-item-has-children > a::after {
-		content: "\00a0\25BC";
-		display: inline-block;
-		font-size: var(--global--font-size-xs);
+		content: "";
+		position: relative;
+		top: calc( var(--primary-nav--padding) / -4);
 		height: inherit;
 		width: inherit;
+		border: solid currentColor;
+		border-width: 0 1px 1px 0;
+		display: inline-block;
+		margin-left: calc( var(--primary-nav--padding) / 2);
+		padding: 3px;
+		transform: rotate(45deg);
 	}
 }
 


### PR DESCRIPTION
We need to update the dropdown arrows to match the comps. This first pass uses a quick CSS-only approach, but needs to be tested to see how it might scale if the font size/padding of the menu were to change in child themes. 

Another option would be to use something like the existing [`varya_add_dropdown_icons()`](https://github.com/Automattic/themes-workspace/blob/master/varya/inc/template-functions.php#L206-L250) function to inject a SVG in there instead (If we do not use that function, we should probably delete it). 

---

Before: 

![Screen Shot 2020-04-01 at 3 43 20 PM](https://user-images.githubusercontent.com/1202812/78179624-84e35f80-742f-11ea-89f9-bf146f39492a.png)
After:

![Screen Shot 2020-04-01 at 3 42 28 PM](https://user-images.githubusercontent.com/1202812/78179561-68dfbe00-742f-11ea-9c23-07fc1f3ed40b.png)
