### PR TITLE
[Varya] Refine site title underline

### DIFF
--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -50,7 +50,22 @@
 		&:hover {
 			color: var(--branding--color-link-hover);
 		}
+
+		&::selection {
+			text-shadow:
+				1px 0px var(--global--color-text-selection), 
+				-1px 0px var(--global--color-text-selection),
+				-2px 0px var(--global--color-text-selection),
+				2px 0px var(--global--color-text-selection),
+				-3px 0px var(--global--color-text-selection),
+				3px 0px var(--global--color-text-selection),
+				-4px 0px var(--global--color-text-selection),
+				4px 0px var(--global--color-text-selection),
+				-5px 0px var(--global--color-text-selection), 
+				5px 0px var(--global--color-text-selection);
+		}
 	}
+
 }
 
 // Site description

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -23,8 +23,24 @@
 	margin-bottom: var(--global--spacing-vertical);
 
 	a {
+		background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);
+		background-position: 0 1.22em;
+		background-repeat: repeat-x;
+		background-size: 8px 2px;
+		border-bottom: none;
 		color: currentColor;
 		font-weight: var(--branding--title--font-weight);
+		text-shadow:
+			1px 0px var(--global--color-background), 
+			-1px 0px var(--global--color-background),
+			-2px 0px var(--global--color-background),
+			2px 0px var(--global--color-background),
+			-3px 0px var(--global--color-background),
+			3px 0px var(--global--color-background),
+			-4px 0px var(--global--color-background),
+			4px 0px var(--global--color-background),
+			-5px 0px var(--global--color-background), 
+			5px 0px var(--global--color-background);
 
 		&:link,
 		&:visited {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2788,8 +2788,14 @@ table th,
 }
 
 .site-title a {
+	background-image: linear-gradient(to left, var(--global--color-secondary) 100%, transparent 100%);
+	background-position: 100% 1.22em;
+	background-repeat: repeat-x;
+	background-size: 8px 2px;
+	border-bottom: none;
 	color: currentColor;
 	font-weight: var(--branding--title--font-weight);
+	text-shadow: -1px 0px var(--global--color-background), 1px 0px var(--global--color-background), 2px 0px var(--global--color-background), -2px 0px var(--global--color-background), 3px 0px var(--global--color-background), -3px 0px var(--global--color-background), 4px 0px var(--global--color-background), -4px 0px var(--global--color-background), 5px 0px var(--global--color-background), -5px 0px var(--global--color-background);
 }
 
 .site-title a:link, .site-title a:visited {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2806,6 +2806,10 @@ table th,
 	color: var(--branding--color-link-hover);
 }
 
+.site-title a::selection {
+	text-shadow: -1px 0px var(--global--color-text-selection), 1px 0px var(--global--color-text-selection), 2px 0px var(--global--color-text-selection), -2px 0px var(--global--color-text-selection), 3px 0px var(--global--color-text-selection), -3px 0px var(--global--color-text-selection), 4px 0px var(--global--color-text-selection), -4px 0px var(--global--color-text-selection), 5px 0px var(--global--color-text-selection), -5px 0px var(--global--color-text-selection);
+}
+
 .site-description {
 	color: currentColor;
 	font-family: var(--branding--description--font-family);

--- a/varya/style.css
+++ b/varya/style.css
@@ -2813,8 +2813,14 @@ table th,
 }
 
 .site-title a {
+	background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);
+	background-position: 0 1.22em;
+	background-repeat: repeat-x;
+	background-size: 8px 2px;
+	border-bottom: none;
 	color: currentColor;
 	font-weight: var(--branding--title--font-weight);
+	text-shadow: 1px 0px var(--global--color-background), -1px 0px var(--global--color-background), -2px 0px var(--global--color-background), 2px 0px var(--global--color-background), -3px 0px var(--global--color-background), 3px 0px var(--global--color-background), -4px 0px var(--global--color-background), 4px 0px var(--global--color-background), -5px 0px var(--global--color-background), 5px 0px var(--global--color-background);
 }
 
 .site-title a:link, .site-title a:visited {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2831,6 +2831,10 @@ table th,
 	color: var(--branding--color-link-hover);
 }
 
+.site-title a::selection {
+	text-shadow: 1px 0px var(--global--color-text-selection), -1px 0px var(--global--color-text-selection), -2px 0px var(--global--color-text-selection), 2px 0px var(--global--color-text-selection), -3px 0px var(--global--color-text-selection), 3px 0px var(--global--color-text-selection), -4px 0px var(--global--color-text-selection), 4px 0px var(--global--color-text-selection), -5px 0px var(--global--color-text-selection), 5px 0px var(--global--color-text-selection);
+}
+
 .site-description {
 	color: currentColor;
 	font-family: var(--branding--description--font-family);


### PR DESCRIPTION
This PR adjusts the site title underline to avoid descenders, addressing this [issue](https://github.com/Automattic/themes-workspace/projects/1#card-35496673).  It uses `background-image` to draw the underline, based on [this reference](https://css-tricks.com/styling-underlines-web/). 

**Before:**
<img width="579" alt="Screen Shot 2020-04-02 at 4 16 46 PM" src="https://user-images.githubusercontent.com/5375500/78297453-a743ae80-74fd-11ea-9ee3-2bc823ef21ee.png">

**After**
<img width="587" alt="Screen Shot 2020-04-02 at 2 59 08 PM" src="https://user-images.githubusercontent.com/5375500/78297503-b7f42480-74fd-11ea-889a-f28f8109a0f1.png">

The tricky part is getting the text-shadows in balance with the "line-height"