### PR TITLE
Varya: Add new line-height control support

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -590,6 +590,15 @@ object {
 	line-height: var(--global--line-height-body);
 }
 
+.wp-block-heading h1[style*="--wp--typography--line-height"], h1[style*="--wp--typography--line-height"], .h1[style*="--wp--typography--line-height"],
+.wp-block-heading h2[style*="--wp--typography--line-height"], h2[style*="--wp--typography--line-height"], .h2[style*="--wp--typography--line-height"],
+.wp-block-heading h3[style*="--wp--typography--line-height"], h3[style*="--wp--typography--line-height"], .h3[style*="--wp--typography--line-height"],
+.wp-block-heading h4[style*="--wp--typography--line-height"], h4[style*="--wp--typography--line-height"], .h4[style*="--wp--typography--line-height"],
+.wp-block-heading h5[style*="--wp--typography--line-height"], h5[style*="--wp--typography--line-height"], .h5[style*="--wp--typography--line-height"],
+.wp-block-heading h6[style*="--wp--typography--line-height"], h6[style*="--wp--typography--line-height"], .h6[style*="--wp--typography--line-height"] {
+	line-height: var(--wp--typography--line-height);
+}
+
 /* Center image block by default in the editor */
 .wp-block-image > div {
 	text-align: center;

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -90,6 +90,7 @@
  * Output
  */
 body {
+	--wp--typography--line-height: var(--global--line-height-body);
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);
@@ -97,10 +98,6 @@ body {
 	font-weight: normal;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
-}
-
-p {
-	line-height: var(--global--line-height-body);
 }
 
 .editor-post-title__block {

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -1091,3 +1091,260 @@ table th,
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
 }
+
+[data-block] [data-block] {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+/**
+ * Vendor styles for the editor
+ */
+/**
+ * Jetpack editor styles
+ */
+/**
+ * Jetpack Block editor styles
+ */
+/* Gutter Options */
+.wp-block-jetpack-layout-grid,
+.wp-block-jetpack-layout-grid > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: var(--layout-grid--gutter-large);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none,
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: var(--layout-grid--gutter-none);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small,
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: var(--layout-grid--gutter-small);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium,
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: var(--layout-grid--gutter-medium);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__large,
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__large > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: var(--layout-grid--gutter-large);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge,
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: var(--layout-grid--gutter-huge);
+}
+
+/* No Gutters Options */
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none {
+	padding-left: var(--layout-grid--gutter-none);
+	padding-right: var(--layout-grid--gutter-none);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small {
+	padding-left: var(--layout-grid--gutter-small);
+	padding-right: var(--layout-grid--gutter-small);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium {
+	padding-left: var(--layout-grid--gutter-medium);
+	padding-right: var(--layout-grid--gutter-medium);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__large {
+	padding-left: var(--layout-grid--gutter-large);
+	padding-right: var(--layout-grid--gutter-large);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__large.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge {
+	padding-left: var(--layout-grid--gutter-huge);
+	padding-right: var(--layout-grid--gutter-huge);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+/* Padding Options */
+.wp-block-jetpack-layout-grid {
+	padding-left: var(--layout-grid--gutter-large);
+	padding-right: var(--layout-grid--gutter-large);
+	/* Individual Column Options */
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column[style^="background-color"] {
+	margin-left: calc(var(--layout-grid--background-offset) * -1);
+	margin-right: calc(var(--layout-grid--background-offset) * -1);
+	padding-left: var(--layout-grid--background-offset);
+	padding-right: var(--layout-grid--background-offset);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+/* Additional, user-set paddings. */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-none {
+	padding: var(--layout-grid--gutter-none);
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-none.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-none[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-none);
+	padding-right: calc(var(--layout-grid--gutter-none) + var(--layout-grid--background-offset));
+	padding-bottom: var(--layout-grid--gutter-none);
+	padding-left: calc(var(--layout-grid--gutter-none) + var(--layout-grid--background-offset));
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-small {
+	padding: var(--layout-grid--gutter-small);
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-small.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-small[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-small);
+	padding-right: calc(var(--layout-grid--gutter-small) + var(--layout-grid--background-offset));
+	padding-bottom: var(--layout-grid--gutter-small);
+	padding-left: calc(var(--layout-grid--gutter-small) + var(--layout-grid--background-offset));
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-medium {
+	padding: var(--layout-grid--gutter-medium);
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-medium.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-medium[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-medium);
+	padding-right: calc(var(--layout-grid--gutter-medium) + var(--layout-grid--background-offset));
+	padding-bottom: var(--layout-grid--gutter-medium);
+	padding-left: calc(var(--layout-grid--gutter-medium) + var(--layout-grid--background-offset));
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-large {
+	padding: var(--layout-grid--gutter-large);
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-large.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-large[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-large);
+	padding-right: calc(var(--layout-grid--gutter-large) + var(--layout-grid--background-offset));
+	padding-bottom: var(--layout-grid--gutter-large);
+	padding-left: calc(var(--layout-grid--gutter-large) + var(--layout-grid--background-offset));
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-huge {
+	padding: var(--layout-grid--gutter-huge);
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-huge.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-huge[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-huge);
+	padding-right: calc(var(--layout-grid--gutter-huge) + var(--layout-grid--background-offset));
+	padding-bottom: var(--layout-grid--gutter-huge);
+	padding-left: calc(var(--layout-grid--gutter-huge) + var(--layout-grid--background-offset));
+}
+
+/* Overlay grid */
+.wp-block-jetpack-layout-grid {
+	/* wpcom-overlay-grid is the classname targeting the grid overlay visual aid displayed in the editor */
+}
+
+.wp-block-jetpack-layout-grid .wpcom-overlay-grid {
+	grid-gap: var(--layout-grid--gutter-large);
+	padding-left: var(--layout-grid--gutter-large);
+	padding-right: var(--layout-grid--gutter-large);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none .wpcom-overlay-grid {
+	grid-gap: var(--layout-grid--gutter-none);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none .wpcom-overlay-grid {
+	padding-left: var(--layout-grid--gutter-none);
+	padding-right: var(--layout-grid--gutter-none);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none.wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small .wpcom-overlay-grid {
+	grid-gap: var(--layout-grid--gutter-small);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small .wpcom-overlay-grid {
+	padding-left: var(--layout-grid--gutter-small);
+	padding-right: var(--layout-grid--gutter-small);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small.wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium .wpcom-overlay-grid {
+	grid-gap: var(--layout-grid--gutter-medium);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium .wpcom-overlay-grid {
+	padding-left: var(--layout-grid--gutter-medium);
+	padding-right: var(--layout-grid--gutter-medium);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium.wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__large .wpcom-overlay-grid {
+	grid-gap: var(--layout-grid--gutter-large);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__large .wpcom-overlay-grid {
+	padding-left: var(--layout-grid--gutter-large);
+	padding-right: var(--layout-grid--gutter-large);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__large.wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge .wpcom-overlay-grid {
+	grid-gap: var(--layout-grid--gutter-huge);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge .wpcom-overlay-grid {
+	padding-left: var(--layout-grid--gutter-huge);
+	padding-right: var(--layout-grid--gutter-huge);
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge.wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
+	padding-left: 0;
+	padding-right: 0;
+}

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -133,7 +133,8 @@ div[data-type="core/button"] {
  * - Styles for basic HTML elemants
  */
 blockquote {
-	padding-left: var(--global--spacing-horizontal);
+	margin: 0;
+	padding: 0;
 }
 
 blockquote p {
@@ -145,8 +146,8 @@ blockquote p {
 blockquote cite,
 blockquote footer {
 	color: var(--global--color-foreground-light);
-	font-size: var(--global--font-size-sm);
-	letter-spacing: var(--global--letter-spacing-sm);
+	font-size: var(--global--font-size-xs);
+	letter-spacing: var(--global--letter-spacing-xs);
 }
 
 blockquote > * {
@@ -760,10 +761,10 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-pullquote {
-	padding: calc( 3 * var(--global--spacing-unit)) 0;
+	padding: calc( 2 * var(--global--spacing-unit)) 0;
 	margin-left: 0;
 	margin-right: 0;
-	text-align: center;
+	text-align: left;
 	border-top-color: var(--pullquote--color-border);
 	border-top-width: var(--pullquote--border-width);
 	border-bottom-color: var(--pullquote--color-border);
@@ -771,15 +772,13 @@ p.has-background:not(.has-background-background-color) a {
 	color: var(--pullquote--color-foreground);
 }
 
-.wp-block-pullquote blockquote {
-	padding-left: 0;
-}
-
 .wp-block-pullquote p {
 	font-family: var(--pullquote--font-family);
-	font-size: var(--heading--font-size-h4);
+	font-size: var(--pullquote--font-size);
+	font-style: var(--pullquote--font-style);
 	letter-spacing: var(--heading--letter-spacing-h4);
-	line-height: var(--heading--line-height);
+	line-height: var(--pullquote--line-height);
+	margin: 0;
 }
 
 .wp-block-pullquote a {
@@ -790,7 +789,7 @@ p.has-background:not(.has-background-background-color) a {
 .wp-block-pullquote cite,
 .wp-block-pullquote footer {
 	color: var(--global--color-foreground-light);
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 }
 
 .wp-block-pullquote:not(.is-style-solid-color) {
@@ -800,6 +799,7 @@ p.has-background:not(.has-background-background-color) a {
 .wp-block-pullquote.is-style-solid-color {
 	background-color: var(--pullquote--color-foreground);
 	color: var(--pullquote--color-background);
+	padding: calc( 2 * var(--global--spacing-unit));
 }
 
 .wp-block-pullquote.is-style-solid-color.alignleft blockquote,
@@ -810,7 +810,9 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
-	padding-left: 0;
+	margin: 0;
+	text-align: left;
+	max-width: 100%;
 }
 
 .wp-block-pullquote.is-style-solid-color .wp-block-pullquote__citation,
@@ -819,37 +821,47 @@ p.has-background:not(.has-background-background-color) a {
 	color: currentColor;
 }
 
-.wp-block-pullquote.alignwide > p,
-.wp-block-pullquote.alignfull > p,
-.wp-block-pullquote.alignwide blockquote,
-.wp-block-pullquote.alignfull blockquote {
-	margin-left: auto;
-	margin-right: auto;
+.wp-block[data-align="full"] .wp-block-pullquote:not(.is-style-solid-color) blockquote {
+	padding: 0 calc( 2 * var(--global--spacing-unit));
 }
 
 .wp-block-quote {
 	border-left-color: var(--quote--border-color);
+	border-left-width: var(--quote--border-width);
 	margin: var(--global--spacing-vertical) 0;
 	padding-left: var(--global--spacing-horizontal);
 }
 
 .wp-block-quote p {
 	font-family: var(--quote--font-family);
-	font-size: var(--heading--font-size-h4);
-	letter-spacing: var(--heading--letter-spacing-h4);
-	line-height: var(--global--line-height-h4);
+	font-size: var(--quote--font-size);
+	line-height: var(--global--line-height-body);
 }
 
 .wp-block-quote.is-large, .wp-block-quote.is-style-large {
-	border: none;
-	padding: 0;
+	border-left: var(--quote--border-width) solid var(--quote--border-color);
+	padding-left: var(--global--spacing-horizontal);
+	/* Resetting margins to match _block-container.scss */
+	margin-top: var(--global--spacing-vertical);
+	margin-bottom: var(--global--spacing-vertical);
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: var(--quote--font-family);
-	font-size: var(--heading--font-size-h3);
-	letter-spacing: var(--heading--letter-spacing-h3);
-	line-height: var(--global--line-height-h3);
+	font-size: var(--quote--font-size-large);
+	font-style: normal;
+}
+
+.wp-block-quote.is-large.has-text-align-right, .wp-block-quote.is-style-large.has-text-align-right {
+	border-left: none;
+	border-right: var(--quote--border-width) solid var(--quote--border-color);
+}
+
+.wp-block-quote.has-text-align-right {
+	border-right: var(--quote--border-width) solid var(--quote--border-color);
+}
+
+.wp-block-quote.has-text-align-center {
+	border: none;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote,
@@ -861,7 +873,7 @@ p.has-background:not(.has-background-background-color) a {
 
 .wp-block-quote .wp-block-quote__citation {
 	color: var(--global--color-foreground-light);
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -754,6 +754,10 @@ dt {
 	color: currentColor;
 }
 
+p {
+	line-height: var(--wp--typography--line-height, --global--line-height-body);
+}
+
 p.has-background {
 	padding: var(--global--spacing-unit);
 }

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -12,7 +12,14 @@
  * - Similar to Blocks but exist outside of the "current" editor context
  */
 /**
+ * Variable configuration
+ * - import all vendor config files
+ */
+/**
  * WooCommerce Variables
+ */
+/**
+ * Jetpack Variables
  */
 body {
 	/* Globals */
@@ -122,6 +129,12 @@ body {
 	--latest-posts--title-font-size: var(--heading--font-size-h3);
 	--latest-posts--description-font-family: var(--global--font-secondary);
 	--latest-posts--description-font-size: var(--global--font-size-sm);
+	--layout-grid--gutter-none: 0px;
+	--layout-grid--gutter-small: calc( var(--global--spacing-unit) / 2);
+	--layout-grid--gutter-medium: var(--global--spacing-unit);
+	--layout-grid--gutter-large: calc( var(--global--spacing-unit) * 2);
+	--layout-grid--gutter-huge: calc( var(--global--spacing-unit) * 3);
+	--layout-grid--background-offset: calc( var(--global--spacing-unit));
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -122,7 +122,7 @@ body {
 	--heading--letter-spacing-h3: var(--global--letter-spacing-xl);
 	--heading--letter-spacing-h2: var(--global--letter-spacing-xxl);
 	--heading--letter-spacing-h1: var(--global--letter-spacing-xxxl);
-	--heading--line-height: 1.25em;
+	--heading--line-height: var(--wp--typography--line-height, 1.25);
 	--heading--font-weight: normal;
 	--heading--font-weight-strong: 600;
 	--latest-posts--title-font-family: var(--heading--font-family);

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -26,7 +26,7 @@ body {
 	--global--font-size-ratio: 1.2;
 	--global--font-size-base: 1em;
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -58,10 +58,10 @@ body {
 	--global--color-alert-warning: gold;
 	--global--color-alert-error: salmon;
 	/* Spacing */
-	--global--spacing-unit: 16px;
+	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
-	--global--spacing-horizontal: 16px;
-	--global--spacing-vertical: 32px;
+	--global--spacing-horizontal: 25px;
+	--global--spacing-vertical: 30px;
 	/* Elevation */
 	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-2: 0px 0px 8px 2px rgba( 0, 0, 0, 0.2 );

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -35,7 +35,7 @@ body {
 	/* Line Height */
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
-	--global--line-height-heading: 1.125;
+	--global--line-height-heading: 1.3;
 	/* Colors */
 	--global--color-primary: #000000;
 	--global--color-primary-hover: #A36265;
@@ -125,16 +125,18 @@ body {
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);
-	--pullquote--font-size: var(--heading--font-size-h4);
-	--pullquote--border-width: 4px;
-	--pullquote--color-border: var(--global--color-foreground);
+	--pullquote--font-size: var(--heading--font-size-h2);
+	--pullquote--font-style: italic;
+	--pullquote--line-height: var(--global--line-height-heading);
+	--pullquote--border-width: 0;
+	--pullquote--color-border: transparent;
 	--pullquote--color-foreground: var(--global--color-foreground);
 	--pullquote--color-background: var(--global--color-background);
-	--quote--border-color: var(--global--color-primary);
-	--quote--border-width: 4px;
-	--quote--font-family: var(--global--font-primary);
-	--quote--font-size: var(--heading--font-size-h4);
-	--quote--font-size-large: var(--heading--font-size-h3);
+	--quote--border-color: var(--global--color-secondary);
+	--quote--border-width: 1px;
+	--quote--font-family: var(--global--font-secondary);
+	--quote--font-size: var(--global--font-size-md);
+	--quote--font-size-large: var(--global--font-size-lg);
 	--separator--border-color: var(--global--color-border);
 	--separator--height: 2px;
 	--separator--width: calc(6 * var(--global--spacing-horizontal));

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -26,7 +26,7 @@
 	--global--font-size-ratio: 1.2;
 	--global--font-size-base: 1em;
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;
@@ -176,11 +176,11 @@
 	--entry-header--font-family: var(--heading--font-family);
 	--entry-header--font-size: var(--heading--font-size-h2);
 	--entry-content--font-family: var(--heading--font-size-h2);
-	--entry-meta--color: var(--global--color-foreground-light);
+	--entry-meta--color: var(--global--color-foreground);
 	--entry-meta--color-link: currentColor;
 	--entry-meta--color-hover: var(--global--color-primary-hover);
 	--entry-meta--font-family: var(--global--font-primary);
-	--entry-meta--font-size: var(--global--font-size-sm);
+	--entry-meta--font-size: var(--global--font-size-xs);
 	--entry-author-bio--font-family: var(--heading--font-family);
 	--entry-author-bio--font-size: var(--heading--font-size-h3);
 	--footer--color-text: var(--global--color-foreground-light);

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -153,12 +153,15 @@
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--heading--font-size-h1);
+	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--logo--max-width: 120px;
 	--branding--logo--max-height: 120px;
+	--branding--logo--max-width-mobile: 96px;
+	--branding--logo--max-height-mobile: 96px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -157,8 +157,8 @@
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
-	--branding--logo--max-width: 128px;
-	--branding--logo--max-height: 128px;
+	--branding--logo--max-width: 120px;
+	--branding--logo--max-height: 120px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -58,10 +58,10 @@
 	--global--color-alert-warning: gold;
 	--global--color-alert-error: salmon;
 	/* Spacing */
-	--global--spacing-unit: 16px;
+	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
-	--global--spacing-horizontal: 16px;
-	--global--spacing-vertical: 32px;
+	--global--spacing-horizontal: 25px;
+	--global--spacing-vertical: 30px;
 	/* Elevation */
 	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-2: 0px 0px 8px 2px rgba( 0, 0, 0, 0.2 );

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -35,7 +35,7 @@
 	/* Line Height */
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
-	--global--line-height-heading: 1.125;
+	--global--line-height-heading: 1.3;
 	/* Colors */
 	--global--color-primary: #000000;
 	--global--color-primary-hover: #A36265;
@@ -125,16 +125,18 @@
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);
-	--pullquote--font-size: var(--heading--font-size-h4);
-	--pullquote--border-width: 4px;
-	--pullquote--color-border: var(--global--color-foreground);
+	--pullquote--font-size: var(--heading--font-size-h2);
+	--pullquote--font-style: italic;
+	--pullquote--line-height: var(--global--line-height-heading);
+	--pullquote--border-width: 0;
+	--pullquote--color-border: transparent;
 	--pullquote--color-foreground: var(--global--color-foreground);
 	--pullquote--color-background: var(--global--color-background);
-	--quote--border-color: var(--global--color-primary);
-	--quote--border-width: 4px;
-	--quote--font-family: var(--global--font-primary);
-	--quote--font-size: var(--heading--font-size-h4);
-	--quote--font-size-large: var(--heading--font-size-h3);
+	--quote--border-color: var(--global--color-secondary);
+	--quote--border-width: 1px;
+	--quote--font-family: var(--global--font-secondary);
+	--quote--font-size: var(--global--font-size-md);
+	--quote--font-size-large: var(--global--font-size-lg);
 	--separator--border-color: var(--global--color-border);
 	--separator--height: 2px;
 	--separator--width: calc(6 * var(--global--spacing-horizontal));

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -122,7 +122,7 @@
 	--heading--letter-spacing-h3: var(--global--letter-spacing-xl);
 	--heading--letter-spacing-h2: var(--global--letter-spacing-xxl);
 	--heading--letter-spacing-h1: var(--global--letter-spacing-xxxl);
-	--heading--line-height: 1.25em;
+	--heading--line-height: var(--wp--typography--line-height, 1.25);
 	--heading--font-weight: normal;
 	--heading--font-weight-strong: 600;
 	--latest-posts--title-font-family: var(--heading--font-family);

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -12,7 +12,14 @@
  * - Similar to Blocks but exist outside of the "current" editor context
  */
 /**
+ * Variable configuration
+ * - import all vendor config files
+ */
+/**
  * WooCommerce Variables
+ */
+/**
+ * Jetpack Variables
  */
 :root {
 	/* Globals */
@@ -122,6 +129,12 @@
 	--latest-posts--title-font-size: var(--heading--font-size-h3);
 	--latest-posts--description-font-family: var(--global--font-secondary);
 	--latest-posts--description-font-size: var(--global--font-size-sm);
+	--layout-grid--gutter-none: 0px;
+	--layout-grid--gutter-small: calc( var(--global--spacing-unit) / 2);
+	--layout-grid--gutter-medium: var(--global--spacing-unit);
+	--layout-grid--gutter-large: calc( var(--global--spacing-unit) * 2);
+	--layout-grid--gutter-huge: calc( var(--global--spacing-unit) * 3);
+	--layout-grid--background-offset: calc( var(--global--spacing-unit));
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -18,7 +18,7 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--font-size-ratio: #{$typescale-ratio};
 	--global--font-size-base: #{$typescale-base};
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -1,5 +1,5 @@
 // Vertical Rhythm Multiplier
-$baseline-unit: 8px;
+$baseline-unit: 10px;
 
 // Typescale Multipliers
 $typescale-root: 18px; // Set 16px/1em default on html
@@ -53,10 +53,10 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--color-alert-error: salmon;
 
 	/* Spacing */
-	--global--spacing-unit: #{2 * $baseline-unit}; // 16px
+	--global--spacing-unit: #{2 * $baseline-unit}; // 20px
 	--global--spacing-measure: unset; // Use ch units here. ie: 60ch = 60 character max-width
-	--global--spacing-horizontal: #{2 * $baseline-unit}; // 16px
-	--global--spacing-vertical: #{4 * $baseline-unit}; // 32px matches default spacing in the editor.
+	--global--spacing-horizontal: #{2.5 * $baseline-unit}; // 25px
+	--global--spacing-vertical: #{3 * $baseline-unit}; // 30px.
 
 	/* Elevation */
 	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -28,7 +28,7 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	/* Line Height */
 	--global--line-height-base: #{$typescale-base / ( $typescale-base * 0 + 1 )};
 	--global--line-height-body: 1.7;
-	--global--line-height-heading: 1.125;
+	--global--line-height-heading: 1.3;
 
 	/* Colors */
 	--global--color-primary: #000000;

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -1,6 +1,7 @@
 @import '../structure/responsive-logic';
 
 body {
+	--wp--typography--line-height: var(--global--line-height-body);
 	color: var(--global--color-foreground);
 	background-color: var(--global--color-background);
 	font-family: var(--global--font-secondary);
@@ -8,10 +9,6 @@ body {
 	font-weight: normal;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
-}
-
-p {
-	line-height: var(--global--line-height-body);
 }
 
 // Set font size of title block the same as body.
@@ -34,7 +31,7 @@ a {
 }
 
 // Gutenberg injects a rule that limits the max width of .wp-block to 580px
-// This line overrides it to use the responsive spacing rules for default width content 
+// This line overrides it to use the responsive spacing rules for default width content
 .wp-block {
 	&:not([data-align="full"]):not([data-align="wide"]){
 		max-width: var(--responsive--aligndefault-width);

--- a/varya/assets/sass/blocks/heading/_config.scss
+++ b/varya/assets/sass/blocks/heading/_config.scss
@@ -15,7 +15,7 @@
 	--heading--letter-spacing-h2: var(--global--letter-spacing-xxl);
 	--heading--letter-spacing-h1: var(--global--letter-spacing-xxxl);
 
-	--heading--line-height: 1.25em;
+	--heading--line-height: var(--wp--typography--line-height, 1.25);
 	--heading--font-weight: normal;
 	--heading--font-weight-strong: 600;
 }

--- a/varya/assets/sass/blocks/heading/_editor.scss
+++ b/varya/assets/sass/blocks/heading/_editor.scss
@@ -48,3 +48,14 @@
 	letter-spacing: var(--heading--letter-spacing-h6);
 	line-height: var(--global--line-height-body);
 }
+
+.wp-block-heading h1, h1, .h1,
+.wp-block-heading h2, h2, .h2,
+.wp-block-heading h3, h3, .h3,
+.wp-block-heading h4, h4, .h4,
+.wp-block-heading h5, h5, .h5,
+.wp-block-heading h6, h6, .h6 {
+	&[style*="--wp--typography--line-height"] {
+		line-height: var(--wp--typography--line-height);
+	}
+}

--- a/varya/assets/sass/blocks/heading/_style.scss
+++ b/varya/assets/sass/blocks/heading/_style.scss
@@ -16,35 +16,35 @@ h6, .h6 {
 h1, .h1 {
 	font-size: var(--heading--font-size-h1);
 	letter-spacing: var(--heading--letter-spacing-h1);
-	line-height: var(--heading--line-height);
+	line-height: var(--wp--typography--line-height, --heading--line-height);
 }
 
 h2, .h2 {
 	font-size: var(--heading--font-size-h2);
 	letter-spacing: var(--heading--letter-spacing-h2);
-	line-height: var(--heading--line-height);
+	line-height: var(--wp--typography--line-height, --heading--line-height);
 }
 
 h3, .h3 {
 	font-size: var(--heading--font-size-h3);
 	letter-spacing: var(--heading--letter-spacing-h3);
-	line-height: var(--heading--line-height);
+	line-height: var(--wp--typography--line-height, --heading--line-height);
 }
 
 h4, .h4 {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
-	line-height: var(--heading--line-height);
+	line-height: var(--wp--typography--line-height, --heading--line-height);
 }
 
 h5, .h5 {
 	font-size: var(--heading--font-size-h5);
 	letter-spacing: var(--heading--letter-spacing-h5);
-	line-height: var(--global--line-height-body);
+	line-height: var(--wp--typography--line-height, --global--line-height-body);
 }
 
 h6, .h6 {
 	font-size: var(--heading--font-size-h6);
 	letter-spacing: var(--heading--letter-spacing-h6);
-	line-height: var(--global--line-height-body);
+	line-height: var(--wp--typography--line-height, --global--line-height-body);
 }

--- a/varya/assets/sass/blocks/paragraph/_editor.scss
+++ b/varya/assets/sass/blocks/paragraph/_editor.scss
@@ -1,4 +1,6 @@
 p {
+	line-height: var(--wp--typography--line-height, --global--line-height-body);
+
 	&.has-background {
 		padding: var(--global--spacing-unit);
 

--- a/varya/assets/sass/blocks/paragraph/_style.scss
+++ b/varya/assets/sass/blocks/paragraph/_style.scss
@@ -1,4 +1,7 @@
 p {
+
+	line-height: var(--wp--typography--line-height, --global--line-height-body);
+
 	// inherits general font style set at <body>
 	&.has-background {
 		padding: var(--global--spacing-unit);

--- a/varya/assets/sass/blocks/pullquote/_config.scss
+++ b/varya/assets/sass/blocks/pullquote/_config.scss
@@ -1,8 +1,10 @@
 @mixin pullquote-variables() {
 	--pullquote--font-family: var(--global--font-primary);
-	--pullquote--font-size: var(--heading--font-size-h4);
-	--pullquote--border-width: 4px; // half of $baseline-unit (8px)
-	--pullquote--color-border: var(--global--color-foreground);
+	--pullquote--font-size: var(--heading--font-size-h2);
+	--pullquote--font-style: italic;
+	--pullquote--line-height: var(--global--line-height-heading);
+	--pullquote--border-width: 0;
+	--pullquote--color-border: transparent;
 	--pullquote--color-foreground: var(--global--color-foreground);
 	--pullquote--color-background: var(--global--color-background);
 }

--- a/varya/assets/sass/blocks/pullquote/_editor.scss
+++ b/varya/assets/sass/blocks/pullquote/_editor.scss
@@ -1,8 +1,8 @@
 .wp-block-pullquote {
-	padding: calc( 3 * var(--global--spacing-unit) ) 0;
+	padding: calc( 2 * var(--global--spacing-unit) ) 0;
 	margin-left: 0;
 	margin-right: 0;
-	text-align: center;
+	text-align: left;
 	// Theme?
 	border-top-color: var(--pullquote--color-border);
 	border-top-width: var(--pullquote--border-width);
@@ -10,15 +10,13 @@
 	border-bottom-width: var(--pullquote--border-width);
 	color: var(--pullquote--color-foreground);
 
-	blockquote {
-		padding-left: 0;
-	}
-
 	p {
 		font-family: var(--pullquote--font-family);
-		font-size: var(--heading--font-size-h4);
+		font-size: var(--pullquote--font-size);
+		font-style: var(--pullquote--font-style);
 		letter-spacing: var(--heading--letter-spacing-h4);
-		line-height: var(--heading--line-height);
+		line-height: var(--pullquote--line-height);
+		margin: 0;
 	}
 
 	a {
@@ -29,7 +27,7 @@
 	cite,
 	footer {
 		color: var(--global--color-foreground-light);
-		font-size: var(--global--font-size-sm);
+		font-size: var(--global--font-size-xs);
 	}
 
 	// Block Options
@@ -41,6 +39,7 @@
 
 		background-color: var(--pullquote--color-foreground);
 		color: var(--pullquote--color-background);
+		padding: calc( 2 * var(--global--spacing-unit) );
 
 		&.alignleft blockquote,
 		&.alignright blockquote {
@@ -50,7 +49,9 @@
 		}
 
 		blockquote {
-			padding-left: 0;
+			margin: 0;
+			text-align: left;
+			max-width: 100%;
 		}
 
 		.wp-block-pullquote__citation,
@@ -60,11 +61,12 @@
 		}
 	}
 
-	&.alignwide > p,
-	&.alignfull > p,
-	&.alignwide blockquote,
-	&.alignfull blockquote {
-		margin-left: auto;
-		margin-right: auto;
+}
+
+.wp-block[data-align="full"] {
+	.wp-block-pullquote:not(.is-style-solid-color) {
+		blockquote {
+			padding: 0 calc( 2 * var(--global--spacing-unit));
+		}
 	}
 }

--- a/varya/assets/sass/blocks/pullquote/_style.scss
+++ b/varya/assets/sass/blocks/pullquote/_style.scss
@@ -1,6 +1,5 @@
 .wp-block-pullquote {
-
-	padding: calc( 3 * var(--global--spacing-unit) ) 0;
+	padding: calc( 2 * var(--global--spacing-unit) ) 0;
 	margin-left: 0;
 	margin-right: 0;
 	text-align: left;
@@ -14,8 +13,10 @@
 	p {
 		font-family: var(--pullquote--font-family);
 		font-size: var(--pullquote--font-size);
+		font-style: var(--pullquote--font-style);
 		letter-spacing: var(--heading--letter-spacing-h4);
-		line-height: var(--heading--line-height);
+		line-height: var(--pullquote--line-height);
+		margin: 0;
 	}
 
 	a {
@@ -26,8 +27,9 @@
 	cite,
 	footer {
 		color: currentColor;
-		font-size: var(--global--font-size-sm);
 		display: block;
+		font-size: var(--global--font-size-xs);
+		text-transform: none;
 	}
 
 	/**
@@ -35,10 +37,6 @@
 	 */
 	&:not(.is-style-solid-color) {
 		background: none;
-
-		blockquote {
-			padding-left: 0;
-		}
 	}
 
 	&.is-style-default {
@@ -54,22 +52,27 @@
     &.is-style-large {
         border-left-color: var(--quote--border-color);
         border-left-style: solid;
-        border-left-width: var(--quote--border-width);
-        padding-left: var(--global--spacing-horizontal);
-    }
+		border-left-width: var(--quote--border-width);
+		font-style: normal;
+	}
+
+	&.alignwide > p,
+	&.alignwide blockquote {
+		max-width: var(--responsive--alignwide-width);
+
+	}
+	&.alignfull:not(.is-style-solid-color) > p,
+	&.alignfull:not(.is-style-solid-color) blockquote {
+		padding: 0 calc( 2 * var(--global--spacing-unit) );
+	}
 
 	&.is-style-solid-color {
 
 		background-color: var(--pullquote--color-foreground);
 		color: var(--pullquote--color-background);
-
-		&:not(.alignleft):not(.alignright) blockquote {
-			@extend %responsive-aligndefault-width;
-		}
+		padding: calc( 2 * var(--global--spacing-unit) );
 
 		blockquote {
-			padding-left: var(--global--spacing-unit);
-			padding-right: var(--global--spacing-unit);
 			max-width: inherit;
 		}
 
@@ -80,12 +83,4 @@
 		}
 	}
 
-	&.alignwide > p,
-	&.alignfull > p,
-	&.alignwide blockquote,
-	&.alignfull blockquote {
-		margin-left: auto;
-		margin-right: auto;
-		@extend %responsive-aligndefault-width;
-	}
 }

--- a/varya/assets/sass/blocks/quote/_config.scss
+++ b/varya/assets/sass/blocks/quote/_config.scss
@@ -1,7 +1,7 @@
 @mixin quote-variables() {
-	--quote--border-color: var(--global--color-primary);
-	--quote--border-width: 4px;
-	--quote--font-family: var(--global--font-primary);
-	--quote--font-size: var(--heading--font-size-h4);
-	--quote--font-size-large: var(--heading--font-size-h3);
+	--quote--border-color: var(--global--color-secondary);
+	--quote--border-width: 1px;
+	--quote--font-family: var(--global--font-secondary);
+	--quote--font-size: var(--global--font-size-md);
+	--quote--font-size-large: var(--global--font-size-lg);
 }

--- a/varya/assets/sass/blocks/quote/_editor.scss
+++ b/varya/assets/sass/blocks/quote/_editor.scss
@@ -1,26 +1,39 @@
 .wp-block-quote {
 	border-left-color: var(--quote--border-color);
+	border-left-width: var(--quote--border-width);
 	margin: var(--global--spacing-vertical) 0;
 	padding-left: var(--global--spacing-horizontal);
 
 	p {
 		font-family: var(--quote--font-family);
-		font-size: var(--heading--font-size-h4);
-		letter-spacing: var(--heading--letter-spacing-h4);
-		line-height: var(--global--line-height-h4);
+		font-size: var(--quote--font-size);
+		line-height: var(--global--line-height-body);
 	}
 
 	&.is-large,
 	&.is-style-large {
-		border: none;
-		padding: 0;
+		border-left: var(--quote--border-width) solid var(--quote--border-color);
+		padding-left: var(--global--spacing-horizontal);
+		/* Resetting margins to match _block-container.scss */
+		margin-top: var(--global--spacing-vertical);
+		margin-bottom: var(--global--spacing-vertical);
 
 		p {
-			font-family: var(--quote--font-family);
-			font-size: var(--heading--font-size-h3);
-			letter-spacing: var(--heading--letter-spacing-h3);
-			line-height: var(--global--line-height-h3);
+			font-size: var(--quote--font-size-large);
+			font-style: normal;
 		}
+		&.has-text-align-right {
+			border-left: none;
+			border-right: var(--quote--border-width) solid var(--quote--border-color);
+		}
+	}
+
+	&.has-text-align-right {
+		border-right: var(--quote--border-width) solid var(--quote--border-color);
+	}
+
+	&.has-text-align-center {
+		border: none;
 	}
 
 	.has-background:not(.has-background-background-color) &,
@@ -32,7 +45,7 @@
 
 	.wp-block-quote__citation {
 		color: var(--global--color-foreground-light);
-		font-size: var(--global--font-size-sm);
+		font-size: var(--global--font-size-xs);
 
 		.has-background:not(.has-background-background-color) &,
 		[class*="background-color"]:not(.has-background-background-color) &,

--- a/varya/assets/sass/blocks/quote/_style.scss
+++ b/varya/assets/sass/blocks/quote/_style.scss
@@ -1,5 +1,4 @@
 .wp-block-quote {
-
 	border-left-color: var(--quote--border-color);
 	border-left-width: var(--quote--border-width);
 	margin: var(--global--spacing-vertical) 0;
@@ -21,14 +20,14 @@
 	p {
 		font-family: var(--quote--font-family);
 		font-size: var(--quote--font-size);
-		line-height: var(--heading--line-height);
+		line-height: var(--global--line-height-body); 
 	}
 
 	.wp-block-quote__citation,
 	cite,
 	footer {
 		color: var(--global--color-foreground-light);
-		font-size: var(--global--font-size-sm);
+		font-size: var(--global--font-size-xs);
 
 		.has-background:not(.has-background-background-color) &,
 		[class*="background-color"]:not(.has-background-background-color) &,
@@ -41,28 +40,35 @@
 	/**
 	 * Block Options
 	 */
-	&[style*="text-align:right"],
-	&[style*="text-align: right"] {
-		border-right-color: var(--quote--border-color);
+	&.has-text-align-right {
+		border-right: var(--quote--border-width) solid var(--quote--border-color);
 	}
 
 	&.is-style-large,
 	&.is-large {
+		border-left: var(--quote--border-width) solid var(--quote--border-color);
+		padding-left: var(--global--spacing-horizontal);
 		/* Resetting margins to match _block-container.scss */
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
-		padding: 0;
 
 		p {
 			font-size: var(--quote--font-size-large);
-			line-height: var(--heading--line-height);
+			font-style: normal;
+		}
+		&.has-text-align-right {
+			border-left: none;
+		}
+
+		&.has-text-align-center {
+			border: none;
 		}
 
 		.wp-block-quote__citation,
 		cite,
 		footer {
 			color: var(--global--color-foreground-light);
-			font-size: var(--global--font-size-sm);
+			font-size: var(--global--font-size-xs);
 		}
 	}
 

--- a/varya/assets/sass/blocks/utilities/_editor.scss
+++ b/varya/assets/sass/blocks/utilities/_editor.scss
@@ -150,4 +150,9 @@
 [data-block] {
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
+
+	[data-block] {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
 }

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -12,7 +12,14 @@
  * - Similar to Blocks but exist outside of the "current" editor context
  */
 /**
+ * Variable configuration
+ * - import all vendor config files
+ */
+/**
  * WooCommerce Variables
+ */
+/**
+ * Jetpack Variables
  */
 body {
 	/* Globals */
@@ -122,6 +129,12 @@ body {
 	--latest-posts--title-font-size: var(--heading--font-size-h3);
 	--latest-posts--description-font-family: var(--global--font-secondary);
 	--latest-posts--description-font-size: var(--global--font-size-sm);
+	--layout-grid--gutter-none: 0px;
+	--layout-grid--gutter-small: calc( var(--global--spacing-unit) / 2);
+	--layout-grid--gutter-medium: var(--global--spacing-unit);
+	--layout-grid--gutter-large: calc( var(--global--spacing-unit) * 2);
+	--layout-grid--gutter-huge: calc( var(--global--spacing-unit) * 3);
+	--layout-grid--background-offset: calc( var(--global--spacing-unit));
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -122,7 +122,7 @@ body {
 	--heading--letter-spacing-h3: var(--global--letter-spacing-xl);
 	--heading--letter-spacing-h2: var(--global--letter-spacing-xxl);
 	--heading--letter-spacing-h1: var(--global--letter-spacing-xxxl);
-	--heading--line-height: 1.25em;
+	--heading--line-height: var(--wp--typography--line-height, 1.25);
 	--heading--font-weight: normal;
 	--heading--font-weight-strong: 600;
 	--latest-posts--title-font-family: var(--heading--font-family);

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -26,7 +26,7 @@ body {
 	--global--font-size-ratio: 1.2;
 	--global--font-size-base: 1em;
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -58,10 +58,10 @@ body {
 	--global--color-alert-warning: gold;
 	--global--color-alert-error: salmon;
 	/* Spacing */
-	--global--spacing-unit: 16px;
+	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
-	--global--spacing-horizontal: 16px;
-	--global--spacing-vertical: 32px;
+	--global--spacing-horizontal: 25px;
+	--global--spacing-vertical: 30px;
 	/* Elevation */
 	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-2: 0px 0px 8px 2px rgba( 0, 0, 0, 0.2 );

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -35,7 +35,7 @@ body {
 	/* Line Height */
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
-	--global--line-height-heading: 1.125;
+	--global--line-height-heading: 1.3;
 	/* Colors */
 	--global--color-primary: #000000;
 	--global--color-primary-hover: #A36265;
@@ -125,16 +125,18 @@ body {
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);
-	--pullquote--font-size: var(--heading--font-size-h4);
-	--pullquote--border-width: 4px;
-	--pullquote--color-border: var(--global--color-foreground);
+	--pullquote--font-size: var(--heading--font-size-h2);
+	--pullquote--font-style: italic;
+	--pullquote--line-height: var(--global--line-height-heading);
+	--pullquote--border-width: 0;
+	--pullquote--color-border: transparent;
 	--pullquote--color-foreground: var(--global--color-foreground);
 	--pullquote--color-background: var(--global--color-background);
-	--quote--border-color: var(--global--color-primary);
-	--quote--border-width: 4px;
-	--quote--font-family: var(--global--font-primary);
-	--quote--font-size: var(--heading--font-size-h4);
-	--quote--font-size-large: var(--heading--font-size-h3);
+	--quote--border-color: var(--global--color-secondary);
+	--quote--border-width: 1px;
+	--quote--font-family: var(--global--font-secondary);
+	--quote--font-size: var(--global--font-size-md);
+	--quote--font-size-large: var(--global--font-size-lg);
 	--separator--border-color: var(--global--color-border);
 	--separator--height: 2px;
 	--separator--width: calc(6 * var(--global--spacing-horizontal));

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -26,7 +26,7 @@
 	--global--font-size-ratio: 1.2;
 	--global--font-size-base: 1em;
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;
@@ -176,11 +176,11 @@
 	--entry-header--font-family: var(--heading--font-family);
 	--entry-header--font-size: var(--heading--font-size-h2);
 	--entry-content--font-family: var(--heading--font-size-h2);
-	--entry-meta--color: var(--global--color-foreground-light);
+	--entry-meta--color: var(--global--color-foreground);
 	--entry-meta--color-link: currentColor;
 	--entry-meta--color-hover: var(--global--color-primary-hover);
 	--entry-meta--font-family: var(--global--font-primary);
-	--entry-meta--font-size: var(--global--font-size-sm);
+	--entry-meta--font-size: var(--global--font-size-xs);
 	--entry-author-bio--font-family: var(--heading--font-family);
 	--entry-author-bio--font-size: var(--heading--font-size-h3);
 	--footer--color-text: var(--global--color-foreground-light);

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -153,12 +153,15 @@
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--heading--font-size-h1);
+	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--logo--max-width: 120px;
 	--branding--logo--max-height: 120px;
+	--branding--logo--max-width-mobile: 96px;
+	--branding--logo--max-height-mobile: 96px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -157,8 +157,8 @@
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
-	--branding--logo--max-width: 128px;
-	--branding--logo--max-height: 128px;
+	--branding--logo--max-width: 120px;
+	--branding--logo--max-height: 120px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -58,10 +58,10 @@
 	--global--color-alert-warning: gold;
 	--global--color-alert-error: salmon;
 	/* Spacing */
-	--global--spacing-unit: 16px;
+	--global--spacing-unit: 20px;
 	--global--spacing-measure: unset;
-	--global--spacing-horizontal: 16px;
-	--global--spacing-vertical: 32px;
+	--global--spacing-horizontal: 25px;
+	--global--spacing-vertical: 30px;
 	/* Elevation */
 	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-2: 0px 0px 8px 2px rgba( 0, 0, 0, 0.2 );

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -35,7 +35,7 @@
 	/* Line Height */
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
-	--global--line-height-heading: 1.125;
+	--global--line-height-heading: 1.3;
 	/* Colors */
 	--global--color-primary: #000000;
 	--global--color-primary-hover: #A36265;
@@ -125,16 +125,18 @@
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);
-	--pullquote--font-size: var(--heading--font-size-h4);
-	--pullquote--border-width: 4px;
-	--pullquote--color-border: var(--global--color-foreground);
+	--pullquote--font-size: var(--heading--font-size-h2);
+	--pullquote--font-style: italic;
+	--pullquote--line-height: var(--global--line-height-heading);
+	--pullquote--border-width: 0;
+	--pullquote--color-border: transparent;
 	--pullquote--color-foreground: var(--global--color-foreground);
 	--pullquote--color-background: var(--global--color-background);
-	--quote--border-color: var(--global--color-primary);
-	--quote--border-width: 4px;
-	--quote--font-family: var(--global--font-primary);
-	--quote--font-size: var(--heading--font-size-h4);
-	--quote--font-size-large: var(--heading--font-size-h3);
+	--quote--border-color: var(--global--color-secondary);
+	--quote--border-width: 1px;
+	--quote--font-family: var(--global--font-secondary);
+	--quote--font-size: var(--global--font-size-md);
+	--quote--font-size-large: var(--global--font-size-lg);
 	--separator--border-color: var(--global--color-border);
 	--separator--height: 2px;
 	--separator--width: calc(6 * var(--global--spacing-horizontal));

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -122,7 +122,7 @@
 	--heading--letter-spacing-h3: var(--global--letter-spacing-xl);
 	--heading--letter-spacing-h2: var(--global--letter-spacing-xxl);
 	--heading--letter-spacing-h1: var(--global--letter-spacing-xxxl);
-	--heading--line-height: 1.25em;
+	--heading--line-height: var(--wp--typography--line-height, 1.25);
 	--heading--font-weight: normal;
 	--heading--font-weight-strong: 600;
 	--latest-posts--title-font-family: var(--heading--font-family);

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -12,7 +12,14 @@
  * - Similar to Blocks but exist outside of the "current" editor context
  */
 /**
+ * Variable configuration
+ * - import all vendor config files
+ */
+/**
  * WooCommerce Variables
+ */
+/**
+ * Jetpack Variables
  */
 :root {
 	/* Globals */
@@ -122,6 +129,12 @@
 	--latest-posts--title-font-size: var(--heading--font-size-h3);
 	--latest-posts--description-font-family: var(--global--font-secondary);
 	--latest-posts--description-font-size: var(--global--font-size-sm);
+	--layout-grid--gutter-none: 0px;
+	--layout-grid--gutter-small: calc( var(--global--spacing-unit) / 2);
+	--layout-grid--gutter-medium: var(--global--spacing-unit);
+	--layout-grid--gutter-large: calc( var(--global--spacing-unit) * 2);
+	--layout-grid--gutter-huge: calc( var(--global--spacing-unit) * 3);
+	--layout-grid--background-offset: calc( var(--global--spacing-unit));
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);

--- a/varya/assets/sass/components/entry/_config.scss
+++ b/varya/assets/sass/components/entry/_config.scss
@@ -7,11 +7,11 @@
 
 	--entry-content--font-family: var(--heading--font-size-h2);
 
-	--entry-meta--color: var(--global--color-foreground-light);
+	--entry-meta--color: var(--global--color-foreground);
 	--entry-meta--color-link: currentColor;
 	--entry-meta--color-hover: var(--global--color-primary-hover);
 	--entry-meta--font-family: var(--global--font-primary);
-	--entry-meta--font-size: var(--global--font-size-sm);
+	--entry-meta--font-size: var(--global--font-size-xs);
 
 	--entry-author-bio--font-family: var(--heading--font-family);
 	--entry-author-bio--font-size: var(--heading--font-size-h3);

--- a/varya/assets/sass/components/entry/_meta.scss
+++ b/varya/assets/sass/components/entry/_meta.scss
@@ -45,10 +45,9 @@
 	}
 }
 
-.entry-meta {
-
-}
-
-.entry-footer {
-
+// Extra specificity to override rules in _vertical-margins.scss
+.site-main > article > .entry-footer {
+	margin-top: calc( var(--global--spacing-vertical) * 3 );
+	padding-top: var(--global--spacing-unit);
+	border-top: var(--separator--height) solid var(--separator--border-color);
 }

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -4,6 +4,7 @@
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--heading--font-size-h1);
+	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) ); // This is a one-off calculation.
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
@@ -11,6 +12,8 @@
 
 	--branding--logo--max-width: 120px;
 	--branding--logo--max-height: 120px;
+	--branding--logo--max-width-mobile: 96px;
+	--branding--logo--max-height-mobile: 96px;
 
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -9,8 +9,8 @@
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
 
-	--branding--logo--max-width: 128px;
-	--branding--logo--max-height: 128px;
+	--branding--logo--max-width: 120px;
+	--branding--logo--max-height: 120px;
 
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -23,8 +23,24 @@
 	margin-bottom: var(--global--spacing-vertical);
 
 	a {
+		background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);
+		background-position: 0 1.22em;
+		background-repeat: repeat-x;
+		background-size: 8px 2px;
+		border-bottom: none;
 		color: currentColor;
 		font-weight: var(--branding--title--font-weight);
+		text-shadow:
+			1px 0px var(--global--color-background), 
+			-1px 0px var(--global--color-background),
+			-2px 0px var(--global--color-background),
+			2px 0px var(--global--color-background),
+			-3px 0px var(--global--color-background),
+			3px 0px var(--global--color-background),
+			-4px 0px var(--global--color-background),
+			4px 0px var(--global--color-background),
+			-5px 0px var(--global--color-background), 
+			5px 0px var(--global--color-background);
 
 		&:link,
 		&:visited {
@@ -34,7 +50,22 @@
 		&:hover {
 			color: var(--branding--color-link-hover);
 		}
+
+		&::selection {
+			text-shadow:
+				1px 0px var(--global--color-text-selection), 
+				-1px 0px var(--global--color-text-selection),
+				-2px 0px var(--global--color-text-selection),
+				2px 0px var(--global--color-text-selection),
+				-3px 0px var(--global--color-text-selection),
+				3px 0px var(--global--color-text-selection),
+				-4px 0px var(--global--color-text-selection),
+				4px 0px var(--global--color-text-selection),
+				-5px 0px var(--global--color-text-selection), 
+				5px 0px var(--global--color-text-selection);
+		}
 	}
+
 }
 
 // Site description

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -20,7 +20,7 @@
 	font-size: var(--branding--title--font-size);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
-	margin-bottom: var(--global--spacing-vertical);
+	margin-bottom: calc( var(--global--spacing-vertical) / 2 );
 
 	a {
 		background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -1,9 +1,3 @@
-// Site logo
-
-.site-logo {
-
-}
-
 // Site branding
 
 .site-branding {
@@ -17,7 +11,7 @@
 
 	color: var(--branding--color-link);
 	font-family: var(--branding--title--font-family);
-	font-size: var(--branding--title--font-size);
+	font-size: var(--branding--title--font-size-mobile);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
 	margin-bottom: calc( var(--global--spacing-vertical) / 2 );
@@ -26,7 +20,7 @@
 		background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);
 		background-position: 0 1.22em;
 		background-repeat: repeat-x;
-		background-size: 8px 2px;
+		background-size: 8px 1.5px;
 		border-bottom: none;
 		color: currentColor;
 		font-weight: var(--branding--title--font-weight);
@@ -66,6 +60,13 @@
 		}
 	}
 
+	@include media(mobile) {
+		font-size: var(--branding--title--font-size);
+
+		a {
+			background-size: 8px 2px;
+		}
+	}
 }
 
 // Site description
@@ -89,11 +90,21 @@ nav a {
 // Site logo
 
 .site-logo {
-	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+
+	margin: calc( var(--global--spacing-vertical) / 2 ) var(--global--spacing-horizontal);
 
 	.custom-logo {
-		max-width: var(--branding--logo--max-width);
-		max-height: var(--branding--logo--max-height);
+		max-width: var(--branding--logo--max-width-mobile);
+		max-height: var(--branding--logo--max-height-mobile);
 		height: auto;
+	}
+
+	@include media(mobile) {
+	
+		.custom-logo {
+			max-width: var(--branding--logo--max-width);
+			max-height: var(--branding--logo--max-height);
+			height: auto;
+		}
 	}
 }

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -4,7 +4,7 @@
 
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	margin-top: var(--global--spacing-vertical);
+	margin-top: calc( var(--global--spacing-vertical) * 1.5 );
 
 	// Menu wrapper
 	& > div {

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -87,10 +87,6 @@
 				z-index: 99999;
 			}
 
-			&:focus-within a {
-			//	outline: none;
-			}
-
 			@include media(mobile) {
 				display: inherit;
 				width: inherit;
@@ -147,9 +143,27 @@
 		}
 	}
 
-	// Menu Link
-	a {
+	// Top-level Item Link Colors
+	.main-menu > .menu-item:hover > a {
+		color: var(--primary-nav--color-link-hover);
+
+		+ svg {
+			fill: var(--primary-nav--color-link-hover);
+		}
+	}
+
+	// Menu Item Link Colors
+	.menu-item > a {
 		color: var(--primary-nav--color-link);
+
+		&:hover {
+			color: var(--primary-nav--color-link-hover);
+		}
+	}
+
+	// Menu Item
+	a {
+		color: currentColor;
 		display: block;
 		font-family: var(--primary-nav--font-family);
 		font-weight: var(--primary-nav--font-weight);
@@ -159,13 +173,10 @@
 			padding: var(--primary-nav--padding);
 		}
 
+		&:hover,
 		&:link,
 		&:visited {
-			color: var(--primary-nav--color-link);
-		}
-
-		&:hover {
-			color: var(--primary-nav--color-link-hover);
+			color: currentColor;
 		}
 	}
 
@@ -184,14 +195,16 @@
 
 	// Show top-level sub-menu indicators above mobile-breakpoint-only
 	@include media(mobile) {
-		& > div > ul > .menu-item-has-children > a {
+		.menu-item-has-children {
 
-			&::after {
-				content: "\00a0\25BC";
+			> a {
+				padding-right: 0;
+			}
+
+			> .svg-icon {
 				display: inline-block;
-				font-size: var(--global--font-size-xs);
-				height: inherit;
-				width: inherit;
+				height: 100%;
+				margin-right: var(--primary-nav--padding);
 			}
 		}
 	}

--- a/varya/assets/sass/components/pagination/_style.scss
+++ b/varya/assets/sass/components/pagination/_style.scss
@@ -45,15 +45,15 @@
 .post-navigation {
 
 	.meta-nav {
-		font-size: var(--global--font-size-sm);
+		font-size: var(--global--font-size-xs);
 		line-height: var(--global--line-height-body);
+		color: var(--global--color-foreground);
 	}
 
 	.post-title {
 		font-family: var(--global--font-primary);
 		font-size: var(--global--font-size-lg);
 		line-height: var(--heading--line-height);
-		font-weight: 600;
 	}
 
 	.nav-links {

--- a/varya/assets/sass/elements/_blockquote.scss
+++ b/varya/assets/sass/elements/_blockquote.scss
@@ -1,6 +1,6 @@
 blockquote {
-
-	padding-left: var(--global--spacing-horizontal);
+	margin: 0;
+	padding: 0;
 
 	p {
 		font-size: var(--heading--font-size-h4);
@@ -11,8 +11,8 @@ blockquote {
 	cite,
 	footer {
 		color: var(--global--color-foreground-light);
-		font-size: var(--global--font-size-sm);
-		letter-spacing: var(--global--letter-spacing-sm);
+		font-size: var(--global--font-size-xs);
+		letter-spacing: var(--global--letter-spacing-xs);
 	}
 
 	& > * {

--- a/varya/assets/sass/structure/_vertical-margins.scss
+++ b/varya/assets/sass/structure/_vertical-margins.scss
@@ -27,8 +27,13 @@
 }
 
 .site-header {
-	padding-top: calc(3 * var(--global--spacing-vertical));
-	padding-bottom: calc(3 * var(--global--spacing-vertical));
+	padding-top: calc(2 * var(--global--spacing-vertical));
+	padding-bottom: calc(2 * var(--global--spacing-vertical));
+
+	@include media(mobile) {
+		padding-top: calc(3 * var(--global--spacing-vertical));
+		padding-bottom: calc(3 * var(--global--spacing-vertical));
+	}
 }
 
 /**

--- a/varya/assets/sass/style-editor.scss
+++ b/varya/assets/sass/style-editor.scss
@@ -19,3 +19,8 @@
 // - These styles replace key Gutenberg Block styles for fonts, colors, and
 //   spacing with CSS-variables overrides
 @import "blocks/editor";
+
+// Vendor
+// - These styles override key Vendor styles for fonts, colors, and
+//   spacing with CSS-variables overrides
+@import "vendors/editor";

--- a/varya/assets/sass/variables-editor.scss
+++ b/varya/assets/sass/variables-editor.scss
@@ -7,7 +7,7 @@
 @import "elements/config";
 @import "blocks/config";
 @import "components/config";
-@import "vendors/woocommerce/config";
+@import "vendors/config";
 
 @include add_variables( editor ) {
 	/* Globals */
@@ -19,6 +19,7 @@
 	@include cover-variables();
 	@include heading-variables();
 	@include latest-posts-variables();
+	@include layout-grid-variables();
 	@include list-variables();
 	@include pullquote-variables();
 	@include quote-variables();

--- a/varya/assets/sass/variables.scss
+++ b/varya/assets/sass/variables.scss
@@ -7,7 +7,7 @@
 @import "elements/config";
 @import "blocks/config";
 @import "components/config";
-@import "vendors/woocommerce/config";
+@import "vendors/config";
 
 @include add_variables( frontend ) {
 	/* Globals */
@@ -19,6 +19,7 @@
 	@include cover-variables();
 	@include heading-variables();
 	@include latest-posts-variables();
+	@include layout-grid-variables();
 	@include list-variables();
 	@include pullquote-variables();
 	@include quote-variables();

--- a/varya/assets/sass/vendors/_config.scss
+++ b/varya/assets/sass/vendors/_config.scss
@@ -1,0 +1,7 @@
+/**
+ * Variable configuration
+ * - import all vendor config files
+ */
+
+@import "woocommerce/config";
+@import "jetpack/config";

--- a/varya/assets/sass/vendors/_editor.scss
+++ b/varya/assets/sass/vendors/_editor.scss
@@ -1,0 +1,6 @@
+/**
+ * Vendor styles for the editor
+ */
+
+// Jetpack
+@import "jetpack/editor";

--- a/varya/assets/sass/vendors/_style.scss
+++ b/varya/assets/sass/vendors/_style.scss
@@ -1,6 +1,9 @@
 /**
- * Vendor styles
+ * Vendor styles for the front-end
  */
 
 // WooCommerce
 @import "woocommerce/style";
+
+// Jetpack
+@import "jetpack/style";

--- a/varya/assets/sass/vendors/jetpack/_config.scss
+++ b/varya/assets/sass/vendors/jetpack/_config.scss
@@ -1,0 +1,6 @@
+/**
+ * Jetpack Variables
+ */
+
+// Block Variables
+@import "blocks/layout-grid/config";

--- a/varya/assets/sass/vendors/jetpack/_editor.scss
+++ b/varya/assets/sass/vendors/jetpack/_editor.scss
@@ -1,0 +1,6 @@
+/**
+ * Jetpack editor styles
+ */
+
+// Blocks
+@import "blocks/editor";

--- a/varya/assets/sass/vendors/jetpack/_style.scss
+++ b/varya/assets/sass/vendors/jetpack/_style.scss
@@ -1,0 +1,6 @@
+/**
+ * Jetpack styles
+ */
+
+// Blocks
+@import "blocks/style";

--- a/varya/assets/sass/vendors/jetpack/blocks/_editor.scss
+++ b/varya/assets/sass/vendors/jetpack/blocks/_editor.scss
@@ -1,0 +1,6 @@
+/**
+ * Jetpack Block editor styles
+ */
+
+// Layout Grid
+@import "layout-grid/editor";

--- a/varya/assets/sass/vendors/jetpack/blocks/_style.scss
+++ b/varya/assets/sass/vendors/jetpack/blocks/_style.scss
@@ -1,0 +1,6 @@
+/**
+ * Jetpack Block styles
+ */
+
+// Layout Grid
+@import "layout-grid/style";

--- a/varya/assets/sass/vendors/jetpack/blocks/layout-grid/_config.scss
+++ b/varya/assets/sass/vendors/jetpack/blocks/layout-grid/_config.scss
@@ -1,0 +1,10 @@
+$layout-gutter-sizes: "none", "small", "medium", "large", "huge";
+
+@mixin layout-grid-variables() {
+	--layout-grid--gutter-none: 0px;
+	--layout-grid--gutter-small: calc( var(--global--spacing-unit) / 2); // 8px
+	--layout-grid--gutter-medium: var(--global--spacing-unit);           // 16px
+	--layout-grid--gutter-large: calc( var(--global--spacing-unit) * 2); // 32px
+	--layout-grid--gutter-huge: calc( var(--global--spacing-unit) * 3);  // 48px
+	--layout-grid--background-offset: calc( var(--global--spacing-unit)); // 16px
+}

--- a/varya/assets/sass/vendors/jetpack/blocks/layout-grid/_editor.scss
+++ b/varya/assets/sass/vendors/jetpack/blocks/layout-grid/_editor.scss
@@ -1,0 +1,106 @@
+@import 'config';
+
+/* Gutter Options */
+.wp-block-jetpack-layout-grid,
+.wp-block-jetpack-layout-grid > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: var(--layout-grid--gutter-large);
+}
+
+@each $size in $layout-gutter-sizes {
+	.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__#{$size},
+	.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__#{$size} > .block-editor-inner-blocks > .block-editor-block-list__layout {
+		grid-gap: var(--layout-grid--gutter-#{$size});
+	}
+}
+
+/* No Gutters Options */
+@each $size in $layout-gutter-sizes {
+	.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__#{$size} {
+		// This padding adds end gutters.
+		padding-left: var(--layout-grid--gutter-#{$size});
+		padding-right: var(--layout-grid--gutter-#{$size});
+
+		// This padding removes end gutters.
+		&.wp-block-jetpack-layout-gutter__nowrap {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+}
+
+/* Padding Options */
+.wp-block-jetpack-layout-grid {
+	padding-left: var(--layout-grid--gutter-large);
+	padding-right: var(--layout-grid--gutter-large);
+
+	/* Individual Column Options */
+	.wp-block-jetpack-layout-grid-column {
+		// Background Offset
+		// When a column has a background color, we add negative margins to enable
+		// some of the gutter to work as default padding.
+		&.has-background,
+		&[style^="background-color"] {
+			margin-left: calc(var(--layout-grid--background-offset) * -1);
+			margin-right: calc(var(--layout-grid--background-offset) * -1);
+			padding-left: var(--layout-grid--background-offset);
+			padding-right: var(--layout-grid--background-offset);
+		}
+	}
+
+	&.wp-block-jetpack-layout-gutter__nowrap {
+		padding-left: 0;
+		padding-right: 0;
+	}
+}
+
+/* Additional, user-set paddings. */
+// Apply both gutter padding and user-set padding, when a background is also set.
+@each $size in $layout-gutter-sizes {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-#{$size} {
+		padding: var(--layout-grid--gutter-#{$size});
+
+		&.has-background,
+		&[style^="background-color"] {
+			padding-top: var(--layout-grid--gutter-#{$size});
+			padding-right: calc(var(--layout-grid--gutter-#{$size}) + var(--layout-grid--background-offset));
+			padding-bottom: var(--layout-grid--gutter-#{$size});
+			padding-left: calc(var(--layout-grid--gutter-#{$size}) + var(--layout-grid--background-offset));
+		}
+	}
+}
+
+/* Overlay grid */
+.wp-block-jetpack-layout-grid {
+	/* wpcom-overlay-grid is the classname targeting the grid overlay visual aid displayed in the editor */
+	.wpcom-overlay-grid {
+		grid-gap: var(--layout-grid--gutter-large);
+		padding-left: var(--layout-grid--gutter-large);
+		padding-right: var(--layout-grid--gutter-large);
+	}
+
+	&.wp-block-jetpack-layout-gutter__nowrap {
+		.wpcom-overlay-grid {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+}
+
+@each $size in $layout-gutter-sizes {
+	.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__#{$size} {
+
+		.wpcom-overlay-grid {
+			grid-gap: var(--layout-grid--gutter-#{$size});
+		}
+
+		.wpcom-overlay-grid {
+			padding-left: var(--layout-grid--gutter-#{$size});
+			padding-right: var(--layout-grid--gutter-#{$size});
+		}
+
+		&.wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+}

--- a/varya/assets/sass/vendors/jetpack/blocks/layout-grid/_style.scss
+++ b/varya/assets/sass/vendors/jetpack/blocks/layout-grid/_style.scss
@@ -1,0 +1,60 @@
+@import 'config';
+
+.wp-block-jetpack-layout-grid {
+	grid-gap: var(--layout-grid--gutter-large) !important;
+	padding-left: var(--layout-grid--gutter-large) !important;
+	padding-right: var(--layout-grid--gutter-large) !important;
+
+	/* Individual Column Options */
+	.wp-block-jetpack-layout-grid-column {
+		// Background Offset
+		// When a column has a background color, we add negative margins to enable
+		// some of the gutter to work as default padding.
+		&.has-background,
+		&[style^="background-color"] {
+			margin-left: calc(var(--layout-grid--background-offset) * -1) !important;
+			margin-right: calc(var(--layout-grid--background-offset) * -1) !important;
+			padding-left: var(--layout-grid--background-offset) !important;
+			padding-right: var(--layout-grid--background-offset) !important;
+		}
+	}
+}
+
+/* Gutter Options */
+@each $size in $layout-gutter-sizes {
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__#{$size} {
+		grid-gap: var(--layout-grid--gutter-#{$size}) !important;
+	}
+}
+
+/* Padding Options */
+@each $size in $layout-gutter-sizes {
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__#{$size} {
+		// This padding adds end gutters.
+		padding-left: var(--layout-grid--gutter-#{$size}) !important;
+		padding-right: var(--layout-grid--gutter-#{$size}) !important;
+
+		// This padding removes end gutters.
+		&.wp-block-jetpack-layout-gutter__nowrap {
+			padding-left: 0 !important;
+			padding-right: 0 !important;
+		}
+	}
+}
+
+// Additional, user-set paddings.
+// Apply both gutter padding and user-set padding, when a background is also set.
+@each $size in $layout-gutter-sizes {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-#{$size} {
+		padding: var(--layout-grid--gutter-#{$size}) !important;
+
+		&.has-background,
+		&[style^="background-color"] {
+			padding-top: var(--layout-grid--gutter-#{$size}) !important;
+			padding-right: calc(var(--layout-grid--gutter-#{$size}) + var(--layout-grid--background-offset)) !important;
+			padding-bottom: var(--layout-grid--gutter-#{$size}) !important;
+			padding-left: calc(var(--layout-grid--gutter-#{$size}) + var(--layout-grid--background-offset)) !important;
+		}
+	}
+}
+

--- a/varya/functions.php
+++ b/varya/functions.php
@@ -85,8 +85,8 @@ if ( ! function_exists( 'varya_setup' ) ) :
 		add_theme_support(
 			'custom-logo',
 			array(
-				'height'      => 128,
-				'width'       => 128,
+				'height'      => 120,
+				'width'       => 120,
 				'flex-width'  => false,
 				'flex-height' => false,
 			)

--- a/varya/functions.php
+++ b/varya/functions.php
@@ -105,11 +105,11 @@ if ( ! function_exists( 'varya_setup' ) ) :
 		add_theme_support( 'editor-styles' );
 
 		// Enqueue editor styles.
-    add_editor_style( array(
-      varya_fonts_url(),
-      './assets/css/variables-editor.css',
-      './assets/css/style-editor.css'
-    ) );
+		add_editor_style( array(
+			varya_fonts_url(),
+			'./assets/css/variables-editor.css',
+			'./assets/css/style-editor.css'
+		) );
 
 		// Add custom editor font sizes.
 		add_theme_support(

--- a/varya/inc/template-functions.php
+++ b/varya/inc/template-functions.php
@@ -210,44 +210,17 @@ function varya_add_dropdown_icons( $output, $item, $depth, $args ) {
 		return $output;
 	}
 
-	if ( in_array( 'mobile-parent-nav-menu-item', $item->classes, true ) && isset( $item->original_id ) ) {
-		// Inject the keyboard_arrow_left SVG inside the parent nav menu item, and let the item link to the parent item.
-		// @todo Only do this for nested submenus? If on a first-level submenu, then really the link could be "#" since the desire is to remove the target entirely.
-		$link = sprintf(
-			'<button class="menu-item-link-return" tabindex="-1">%s',
-			varya_get_icon_svg( 'chevron_left', 24 )
-		);
+	if ( 'menu-1' == $args->theme_location && $depth === 0 ) {
+		if ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
 
-		// replace opening <a> with <button>
-		$output = preg_replace(
-			'/<a\s.*?>/',
-			$link,
-			$output,
-			1 // Limit.
-		);
-
-		// replace closing </a> with </button>
-		$output = preg_replace(
-			'#</a>#i',
-			'</button>',
-			$output,
-			1 // Limit.
-		);
-
-	} elseif ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
-
-		// Add SVG icon to parent items.
-		$icon = varya_get_icon_svg( 'keyboard_arrow_down', 24 );
-
-		$output .= sprintf(
-			'<button class="submenu-expand" tabindex="-1">%s</button>',
-			$icon
-		);
+			// Add SVG icon to parent items.
+			$output .= varya_get_icon_svg( 'keyboard_arrow_down', 24 );
+		}
 	}
 
 	return $output;
 }
-// add_filter( 'walker_nav_menu_start_el', 'varya_add_dropdown_icons', 10, 4 );
+add_filter( 'walker_nav_menu_start_el', 'varya_add_dropdown_icons', 10, 4 );
 
 /**
  * Create a nav menu item to be displayed on mobile to navigate from submenu back to the parent.

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2115,6 +2115,10 @@ dd {
 	}
 }
 
+p {
+	line-height: var(--wp--typography--line-height, --global--line-height-body);
+}
+
 p.has-background {
 	padding: var(--global--spacing-unit);
 }

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3764,7 +3764,7 @@ img#wpstats {
 }
 
 /**
- * Vendor styles
+ * Vendor styles for the front-end
  */
 /**
  * WooCommerce styles
@@ -5539,4 +5539,151 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 		margin-right: calc(1.5 * var(--global--spacing-unit));
 		margin-left: auto;
 	}
+}
+
+/**
+ * Jetpack styles
+ */
+/**
+ * Jetpack Block styles
+ */
+.wp-block-jetpack-layout-grid {
+	grid-gap: var(--layout-grid--gutter-large) !important;
+	padding-right: var(--layout-grid--gutter-large) !important;
+	padding-left: var(--layout-grid--gutter-large) !important;
+	/* Individual Column Options */
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column[style^="background-color"] {
+	margin-right: calc(var(--layout-grid--background-offset) * -1) !important;
+	margin-left: calc(var(--layout-grid--background-offset) * -1) !important;
+	padding-right: var(--layout-grid--background-offset) !important;
+	padding-left: var(--layout-grid--background-offset) !important;
+}
+
+/* Gutter Options */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none {
+	grid-gap: var(--layout-grid--gutter-none) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__small {
+	grid-gap: var(--layout-grid--gutter-small) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__medium {
+	grid-gap: var(--layout-grid--gutter-medium) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__large {
+	grid-gap: var(--layout-grid--gutter-large) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__huge {
+	grid-gap: var(--layout-grid--gutter-huge) !important;
+}
+
+/* Padding Options */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none {
+	padding-right: var(--layout-grid--gutter-none) !important;
+	padding-left: var(--layout-grid--gutter-none) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none.wp-block-jetpack-layout-gutter__nowrap {
+	padding-right: 0 !important;
+	padding-left: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__small {
+	padding-right: var(--layout-grid--gutter-small) !important;
+	padding-left: var(--layout-grid--gutter-small) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__small.wp-block-jetpack-layout-gutter__nowrap {
+	padding-right: 0 !important;
+	padding-left: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__medium {
+	padding-right: var(--layout-grid--gutter-medium) !important;
+	padding-left: var(--layout-grid--gutter-medium) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__medium.wp-block-jetpack-layout-gutter__nowrap {
+	padding-right: 0 !important;
+	padding-left: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__large {
+	padding-right: var(--layout-grid--gutter-large) !important;
+	padding-left: var(--layout-grid--gutter-large) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__large.wp-block-jetpack-layout-gutter__nowrap {
+	padding-right: 0 !important;
+	padding-left: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__huge {
+	padding-right: var(--layout-grid--gutter-huge) !important;
+	padding-left: var(--layout-grid--gutter-huge) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__huge.wp-block-jetpack-layout-gutter__nowrap {
+	padding-right: 0 !important;
+	padding-left: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-none {
+	padding: var(--layout-grid--gutter-none) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-none.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-none[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-none) !important;
+	padding-left: calc(var(--layout-grid--gutter-none) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-none) !important;
+	padding-right: calc(var(--layout-grid--gutter-none) + var(--layout-grid--background-offset)) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-small {
+	padding: var(--layout-grid--gutter-small) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-small.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-small[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-small) !important;
+	padding-left: calc(var(--layout-grid--gutter-small) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-small) !important;
+	padding-right: calc(var(--layout-grid--gutter-small) + var(--layout-grid--background-offset)) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-medium {
+	padding: var(--layout-grid--gutter-medium) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-medium.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-medium[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-medium) !important;
+	padding-left: calc(var(--layout-grid--gutter-medium) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-medium) !important;
+	padding-right: calc(var(--layout-grid--gutter-medium) + var(--layout-grid--background-offset)) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-large {
+	padding: var(--layout-grid--gutter-large) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-large.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-large[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-large) !important;
+	padding-left: calc(var(--layout-grid--gutter-large) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-large) !important;
+	padding-right: calc(var(--layout-grid--gutter-large) + var(--layout-grid--background-offset)) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-huge {
+	padding: var(--layout-grid--gutter-huge) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-huge.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-huge[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-huge) !important;
+	padding-left: calc(var(--layout-grid--gutter-huge) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-huge) !important;
+	padding-right: calc(var(--layout-grid--gutter-huge) + var(--layout-grid--background-offset)) !important;
 }

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2791,7 +2791,7 @@ table th,
 	font-size: var(--branding--title--font-size);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
-	margin-bottom: var(--global--spacing-vertical);
+	margin-bottom: calc( var(--global--spacing-vertical) / 2);
 }
 
 .site-title a {
@@ -2847,7 +2847,7 @@ nav a {
 .main-navigation {
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	margin-top: var(--global--spacing-vertical);
+	margin-top: calc( var(--global--spacing-vertical) * 1.5);
 }
 
 .main-navigation > div {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2788,8 +2788,14 @@ table th,
 }
 
 .site-title a {
+	background-image: linear-gradient(to left, var(--global--color-secondary) 100%, transparent 100%);
+	background-position: 100% 1.22em;
+	background-repeat: repeat-x;
+	background-size: 8px 2px;
+	border-bottom: none;
 	color: currentColor;
 	font-weight: var(--branding--title--font-weight);
+	text-shadow: -1px 0px var(--global--color-background), 1px 0px var(--global--color-background), 2px 0px var(--global--color-background), -2px 0px var(--global--color-background), 3px 0px var(--global--color-background), -3px 0px var(--global--color-background), 4px 0px var(--global--color-background), -4px 0px var(--global--color-background), 5px 0px var(--global--color-background), -5px 0px var(--global--color-background);
 }
 
 .site-title a:link, .site-title a:visited {
@@ -2798,6 +2804,10 @@ table th,
 
 .site-title a:hover {
 	color: var(--branding--color-link-hover);
+}
+
+.site-title a::selection {
+	text-shadow: -1px 0px var(--global--color-text-selection), 1px 0px var(--global--color-text-selection), 2px 0px var(--global--color-text-selection), -2px 0px var(--global--color-text-selection), 3px 0px var(--global--color-text-selection), -3px 0px var(--global--color-text-selection), 4px 0px var(--global--color-text-selection), -4px 0px var(--global--color-text-selection), 5px 0px var(--global--color-text-selection), -5px 0px var(--global--color-text-selection);
 }
 
 .site-description {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3296,6 +3296,12 @@ nav a {
 	margin-left: calc(0.25 * var(--global--spacing-unit));
 }
 
+.site-main > article > .entry-footer {
+	margin-top: calc( var(--global--spacing-vertical) * 3);
+	padding-top: var(--global--spacing-unit);
+	border-top: var(--separator--height) solid var(--separator--border-color);
+}
+
 /**
  * Post Thumbnails
  */
@@ -3357,15 +3363,15 @@ nav a {
 }
 
 .post-navigation .meta-nav {
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 	line-height: var(--global--line-height-body);
+	color: var(--global--color-foreground);
 }
 
 .post-navigation .post-title {
 	font-family: var(--global--font-primary);
 	font-size: var(--global--font-size-lg);
 	line-height: var(--heading--line-height);
-	font-weight: 600;
 }
 
 @media only screen and (min-width: 482px) {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -183,8 +183,15 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 }
 
 .site-header {
-	padding-top: calc(3 * var(--global--spacing-vertical));
-	padding-bottom: calc(3 * var(--global--spacing-vertical));
+	padding-top: calc(2 * var(--global--spacing-vertical));
+	padding-bottom: calc(2 * var(--global--spacing-vertical));
+}
+
+@media only screen and (min-width: 482px) {
+	.site-header {
+		padding-top: calc(3 * var(--global--spacing-vertical));
+		padding-bottom: calc(3 * var(--global--spacing-vertical));
+	}
 }
 
 /**
@@ -2788,7 +2795,7 @@ table th,
 .site-title {
 	color: var(--branding--color-link);
 	font-family: var(--branding--title--font-family);
-	font-size: var(--branding--title--font-size);
+	font-size: var(--branding--title--font-size-mobile);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
 	margin-bottom: calc( var(--global--spacing-vertical) / 2);
@@ -2798,7 +2805,7 @@ table th,
 	background-image: linear-gradient(to left, var(--global--color-secondary) 100%, transparent 100%);
 	background-position: 100% 1.22em;
 	background-repeat: repeat-x;
-	background-size: 8px 2px;
+	background-size: 8px 1.5px;
 	border-bottom: none;
 	color: currentColor;
 	font-weight: var(--branding--title--font-weight);
@@ -2815,6 +2822,15 @@ table th,
 
 .site-title a::selection {
 	text-shadow: -1px 0px var(--global--color-text-selection), 1px 0px var(--global--color-text-selection), 2px 0px var(--global--color-text-selection), -2px 0px var(--global--color-text-selection), 3px 0px var(--global--color-text-selection), -3px 0px var(--global--color-text-selection), 4px 0px var(--global--color-text-selection), -4px 0px var(--global--color-text-selection), 5px 0px var(--global--color-text-selection), -5px 0px var(--global--color-text-selection);
+}
+
+@media only screen and (min-width: 482px) {
+	.site-title {
+		font-size: var(--branding--title--font-size);
+	}
+	.site-title a {
+		background-size: 8px 2px;
+	}
 }
 
 .site-description {
@@ -2835,13 +2851,21 @@ nav a {
 }
 
 .site-logo {
-	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+	margin: calc( var(--global--spacing-vertical) / 2) var(--global--spacing-horizontal);
 }
 
 .site-logo .custom-logo {
-	max-width: var(--branding--logo--max-width);
-	max-height: var(--branding--logo--max-height);
+	max-width: var(--branding--logo--max-width-mobile);
+	max-height: var(--branding--logo--max-height-mobile);
 	height: auto;
+}
+
+@media only screen and (min-width: 482px) {
+	.site-logo .custom-logo {
+		max-width: var(--branding--logo--max-width);
+		max-height: var(--branding--logo--max-height);
+		height: auto;
+	}
 }
 
 .main-navigation {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -91,10 +91,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 /**
  * Extends
  */
-.default-max-width, .wp-block-pullquote.is-style-solid-color:not(.alignleft):not(.alignright) blockquote, .wp-block-pullquote.alignwide > p,
-.wp-block-pullquote.alignfull > p,
-.wp-block-pullquote.alignwide blockquote,
-.wp-block-pullquote.alignfull blockquote, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce),
+.default-max-width, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce),
 .entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .navigation {
 	max-width: var(--responsive--aligndefault-width);
 	margin-right: auto;
@@ -939,7 +936,8 @@ footer {
  * - Styles for basic HTML elemants
  */
 blockquote {
-	padding-right: var(--global--spacing-horizontal);
+	margin: 0;
+	padding: 0;
 }
 
 blockquote p {
@@ -951,8 +949,8 @@ blockquote p {
 blockquote cite,
 blockquote footer {
 	color: var(--global--color-foreground-light);
-	font-size: var(--global--font-size-sm);
-	letter-spacing: var(--global--letter-spacing-sm);
+	font-size: var(--global--font-size-xs);
+	letter-spacing: var(--global--letter-spacing-xs);
 }
 
 blockquote > * {
@@ -2185,7 +2183,7 @@ p.has-background {
 }
 
 .wp-block-pullquote {
-	padding: calc( 3 * var(--global--spacing-unit)) 0;
+	padding: calc( 2 * var(--global--spacing-unit)) 0;
 	margin-right: 0;
 	margin-left: 0;
 	text-align: right;
@@ -2202,8 +2200,10 @@ p.has-background {
 .wp-block-pullquote p {
 	font-family: var(--pullquote--font-family);
 	font-size: var(--pullquote--font-size);
+	font-style: var(--pullquote--font-style);
 	letter-spacing: var(--heading--letter-spacing-h4);
-	line-height: var(--heading--line-height);
+	line-height: var(--pullquote--line-height);
+	margin: 0;
 }
 
 .wp-block-pullquote a {
@@ -2214,16 +2214,13 @@ p.has-background {
 .wp-block-pullquote cite,
 .wp-block-pullquote footer {
 	color: currentColor;
-	font-size: var(--global--font-size-sm);
 	display: block;
+	font-size: var(--global--font-size-xs);
+	text-transform: none;
 }
 
 .wp-block-pullquote:not(.is-style-solid-color) {
 	background: none;
-}
-
-.wp-block-pullquote:not(.is-style-solid-color) blockquote {
-	padding-right: 0;
 }
 
 .wp-block-pullquote.is-style-default.alignleft blockquote > *, .wp-block-pullquote.is-style-default.aligncenter blockquote > *, .wp-block-pullquote.is-style-default.alignright blockquote > * {
@@ -2234,17 +2231,26 @@ p.has-background {
 	border-right-color: var(--quote--border-color);
 	border-right-style: solid;
 	border-right-width: var(--quote--border-width);
-	padding-right: var(--global--spacing-horizontal);
+	font-style: normal;
+}
+
+.wp-block-pullquote.alignwide > p,
+.wp-block-pullquote.alignwide blockquote {
+	max-width: var(--responsive--alignwide-width);
+}
+
+.wp-block-pullquote.alignfull:not(.is-style-solid-color) > p,
+.wp-block-pullquote.alignfull:not(.is-style-solid-color) blockquote {
+	padding: 0 calc( 2 * var(--global--spacing-unit));
 }
 
 .wp-block-pullquote.is-style-solid-color {
 	background-color: var(--pullquote--color-foreground);
 	color: var(--pullquote--color-background);
+	padding: calc( 2 * var(--global--spacing-unit));
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
-	padding-right: var(--global--spacing-unit);
-	padding-left: var(--global--spacing-unit);
 	max-width: inherit;
 }
 
@@ -2252,14 +2258,6 @@ p.has-background {
 .wp-block-pullquote.is-style-solid-color cite,
 .wp-block-pullquote.is-style-solid-color footer {
 	color: currentColor;
-}
-
-.wp-block-pullquote.alignwide > p,
-.wp-block-pullquote.alignfull > p,
-.wp-block-pullquote.alignwide blockquote,
-.wp-block-pullquote.alignfull blockquote {
-	margin-right: auto;
-	margin-left: auto;
 }
 
 .wp-block-quote {
@@ -2288,14 +2286,14 @@ p.has-background {
 .wp-block-quote p {
 	font-family: var(--quote--font-family);
 	font-size: var(--quote--font-size);
-	line-height: var(--heading--line-height);
+	line-height: var(--global--line-height-body);
 }
 
 .wp-block-quote .wp-block-quote__citation,
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--global--color-foreground-light);
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
@@ -2319,20 +2317,29 @@ p.has-background {
 	color: currentColor;
 }
 
-.wp-block-quote[style*="text-align:right"], .wp-block-quote[style*="text-align: right"] {
-	border-left-color: var(--quote--border-color);
+.wp-block-quote.has-text-align-right {
+	border-left: var(--quote--border-width) solid var(--quote--border-color);
 }
 
 .wp-block-quote.is-style-large, .wp-block-quote.is-large {
+	border-right: var(--quote--border-width) solid var(--quote--border-color);
+	padding-right: var(--global--spacing-horizontal);
 	/* Resetting margins to match _block-container.scss */
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
-	padding: 0;
 }
 
 .wp-block-quote.is-style-large p, .wp-block-quote.is-large p {
 	font-size: var(--quote--font-size-large);
-	line-height: var(--heading--line-height);
+	font-style: normal;
+}
+
+.wp-block-quote.is-style-large.has-text-align-right, .wp-block-quote.is-large.has-text-align-right {
+	border-right: none;
+}
+
+.wp-block-quote.is-style-large.has-text-align-center, .wp-block-quote.is-large.has-text-align-center {
+	border: none;
 }
 
 .wp-block-quote.is-style-large .wp-block-quote__citation,
@@ -2341,7 +2348,7 @@ p.has-background {
 .wp-block-quote.is-large cite,
 .wp-block-quote.is-large footer {
 	color: var(--global--color-foreground-light);
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote,

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2987,8 +2987,24 @@ nav a {
 	width: 100%;
 }
 
-.main-navigation a {
+.main-navigation .main-menu > .menu-item:hover > a {
+	color: var(--primary-nav--color-link-hover);
+}
+
+.main-navigation .main-menu > .menu-item:hover > a + svg {
+	fill: var(--primary-nav--color-link-hover);
+}
+
+.main-navigation .menu-item > a {
 	color: var(--primary-nav--color-link);
+}
+
+.main-navigation .menu-item > a:hover {
+	color: var(--primary-nav--color-link-hover);
+}
+
+.main-navigation a {
+	color: currentColor;
 	display: block;
 	font-family: var(--primary-nav--font-family);
 	font-weight: var(--primary-nav--font-weight);
@@ -3001,12 +3017,8 @@ nav a {
 	}
 }
 
-.main-navigation a:link, .main-navigation a:visited {
-	color: var(--primary-nav--color-link);
-}
-
-.main-navigation a:hover {
-	color: var(--primary-nav--color-link-hover);
+.main-navigation a:hover, .main-navigation a:link, .main-navigation a:visited {
+	color: currentColor;
 }
 
 .main-navigation .sub-menu {
@@ -3020,12 +3032,13 @@ nav a {
 }
 
 @media only screen and (min-width: 482px) {
-	.main-navigation > div > ul > .menu-item-has-children > a::after {
-		content: "\00a0\25BC";
+	.main-navigation .menu-item-has-children > a {
+		padding-left: 0;
+	}
+	.main-navigation .menu-item-has-children > .svg-icon {
 		display: inline-block;
-		font-size: var(--global--font-size-xs);
-		height: inherit;
-		width: inherit;
+		height: 100%;
+		margin-left: var(--primary-nav--padding);
 	}
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -191,8 +191,15 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 }
 
 .site-header {
-	padding-top: calc(3 * var(--global--spacing-vertical));
-	padding-bottom: calc(3 * var(--global--spacing-vertical));
+	padding-top: calc(2 * var(--global--spacing-vertical));
+	padding-bottom: calc(2 * var(--global--spacing-vertical));
+}
+
+@media only screen and (min-width: 482px) {
+	.site-header {
+		padding-top: calc(3 * var(--global--spacing-vertical));
+		padding-bottom: calc(3 * var(--global--spacing-vertical));
+	}
 }
 
 /**
@@ -2813,7 +2820,7 @@ table th,
 .site-title {
 	color: var(--branding--color-link);
 	font-family: var(--branding--title--font-family);
-	font-size: var(--branding--title--font-size);
+	font-size: var(--branding--title--font-size-mobile);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
 	margin-bottom: calc( var(--global--spacing-vertical) / 2);
@@ -2823,7 +2830,7 @@ table th,
 	background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);
 	background-position: 0 1.22em;
 	background-repeat: repeat-x;
-	background-size: 8px 2px;
+	background-size: 8px 1.5px;
 	border-bottom: none;
 	color: currentColor;
 	font-weight: var(--branding--title--font-weight);
@@ -2840,6 +2847,15 @@ table th,
 
 .site-title a::selection {
 	text-shadow: 1px 0px var(--global--color-text-selection), -1px 0px var(--global--color-text-selection), -2px 0px var(--global--color-text-selection), 2px 0px var(--global--color-text-selection), -3px 0px var(--global--color-text-selection), 3px 0px var(--global--color-text-selection), -4px 0px var(--global--color-text-selection), 4px 0px var(--global--color-text-selection), -5px 0px var(--global--color-text-selection), 5px 0px var(--global--color-text-selection);
+}
+
+@media only screen and (min-width: 482px) {
+	.site-title {
+		font-size: var(--branding--title--font-size);
+	}
+	.site-title a {
+		background-size: 8px 2px;
+	}
 }
 
 .site-description {
@@ -2860,13 +2876,21 @@ nav a {
 }
 
 .site-logo {
-	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+	margin: calc( var(--global--spacing-vertical) / 2) var(--global--spacing-horizontal);
 }
 
 .site-logo .custom-logo {
-	max-width: var(--branding--logo--max-width);
-	max-height: var(--branding--logo--max-height);
+	max-width: var(--branding--logo--max-width-mobile);
+	max-height: var(--branding--logo--max-height-mobile);
 	height: auto;
+}
+
+@media only screen and (min-width: 482px) {
+	.site-logo .custom-logo {
+		max-width: var(--branding--logo--max-width);
+		max-height: var(--branding--logo--max-height);
+		height: auto;
+	}
 }
 
 .main-navigation {

--- a/varya/style.css
+++ b/varya/style.css
@@ -3789,7 +3789,7 @@ img#wpstats {
 }
 
 /**
- * Vendor styles
+ * Vendor styles for the front-end
  */
 /**
  * WooCommerce styles
@@ -5564,4 +5564,151 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 		margin-left: calc(1.5 * var(--global--spacing-unit));
 		margin-right: auto;
 	}
+}
+
+/**
+ * Jetpack styles
+ */
+/**
+ * Jetpack Block styles
+ */
+.wp-block-jetpack-layout-grid {
+	grid-gap: var(--layout-grid--gutter-large) !important;
+	padding-left: var(--layout-grid--gutter-large) !important;
+	padding-right: var(--layout-grid--gutter-large) !important;
+	/* Individual Column Options */
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column[style^="background-color"] {
+	margin-left: calc(var(--layout-grid--background-offset) * -1) !important;
+	margin-right: calc(var(--layout-grid--background-offset) * -1) !important;
+	padding-left: var(--layout-grid--background-offset) !important;
+	padding-right: var(--layout-grid--background-offset) !important;
+}
+
+/* Gutter Options */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none {
+	grid-gap: var(--layout-grid--gutter-none) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__small {
+	grid-gap: var(--layout-grid--gutter-small) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__medium {
+	grid-gap: var(--layout-grid--gutter-medium) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__large {
+	grid-gap: var(--layout-grid--gutter-large) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__huge {
+	grid-gap: var(--layout-grid--gutter-huge) !important;
+}
+
+/* Padding Options */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none {
+	padding-left: var(--layout-grid--gutter-none) !important;
+	padding-right: var(--layout-grid--gutter-none) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__small {
+	padding-left: var(--layout-grid--gutter-small) !important;
+	padding-right: var(--layout-grid--gutter-small) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__small.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__medium {
+	padding-left: var(--layout-grid--gutter-medium) !important;
+	padding-right: var(--layout-grid--gutter-medium) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__medium.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__large {
+	padding-left: var(--layout-grid--gutter-large) !important;
+	padding-right: var(--layout-grid--gutter-large) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__large.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__huge {
+	padding-left: var(--layout-grid--gutter-huge) !important;
+	padding-right: var(--layout-grid--gutter-huge) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__huge.wp-block-jetpack-layout-gutter__nowrap {
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-none {
+	padding: var(--layout-grid--gutter-none) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-none.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-none[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-none) !important;
+	padding-right: calc(var(--layout-grid--gutter-none) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-none) !important;
+	padding-left: calc(var(--layout-grid--gutter-none) + var(--layout-grid--background-offset)) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-small {
+	padding: var(--layout-grid--gutter-small) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-small.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-small[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-small) !important;
+	padding-right: calc(var(--layout-grid--gutter-small) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-small) !important;
+	padding-left: calc(var(--layout-grid--gutter-small) + var(--layout-grid--background-offset)) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-medium {
+	padding: var(--layout-grid--gutter-medium) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-medium.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-medium[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-medium) !important;
+	padding-right: calc(var(--layout-grid--gutter-medium) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-medium) !important;
+	padding-left: calc(var(--layout-grid--gutter-medium) + var(--layout-grid--background-offset)) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-large {
+	padding: var(--layout-grid--gutter-large) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-large.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-large[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-large) !important;
+	padding-right: calc(var(--layout-grid--gutter-large) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-large) !important;
+	padding-left: calc(var(--layout-grid--gutter-large) + var(--layout-grid--background-offset)) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-huge {
+	padding: var(--layout-grid--gutter-huge) !important;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-huge.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.wp-block-jetpack-layout-grid__padding-huge[style^="background-color"] {
+	padding-top: var(--layout-grid--gutter-huge) !important;
+	padding-right: calc(var(--layout-grid--gutter-huge) + var(--layout-grid--background-offset)) !important;
+	padding-bottom: var(--layout-grid--gutter-huge) !important;
+	padding-left: calc(var(--layout-grid--gutter-huge) + var(--layout-grid--background-offset)) !important;
 }

--- a/varya/style.css
+++ b/varya/style.css
@@ -91,10 +91,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 /**
  * Extends
  */
-.default-max-width, .wp-block-pullquote.is-style-solid-color:not(.alignleft):not(.alignright) blockquote, .wp-block-pullquote.alignwide > p,
-.wp-block-pullquote.alignfull > p,
-.wp-block-pullquote.alignwide blockquote,
-.wp-block-pullquote.alignfull blockquote, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce),
+.default-max-width, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce),
 .entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .navigation {
 	max-width: var(--responsive--aligndefault-width);
 	margin-left: auto;
@@ -947,7 +944,8 @@ footer {
  * - Styles for basic HTML elemants
  */
 blockquote {
-	padding-left: var(--global--spacing-horizontal);
+	margin: 0;
+	padding: 0;
 }
 
 blockquote p {
@@ -959,8 +957,8 @@ blockquote p {
 blockquote cite,
 blockquote footer {
 	color: var(--global--color-foreground-light);
-	font-size: var(--global--font-size-sm);
-	letter-spacing: var(--global--letter-spacing-sm);
+	font-size: var(--global--font-size-xs);
+	letter-spacing: var(--global--letter-spacing-xs);
 }
 
 blockquote > * {
@@ -2193,7 +2191,7 @@ p.has-background {
 }
 
 .wp-block-pullquote {
-	padding: calc( 3 * var(--global--spacing-unit)) 0;
+	padding: calc( 2 * var(--global--spacing-unit)) 0;
 	margin-left: 0;
 	margin-right: 0;
 	text-align: left;
@@ -2210,8 +2208,10 @@ p.has-background {
 .wp-block-pullquote p {
 	font-family: var(--pullquote--font-family);
 	font-size: var(--pullquote--font-size);
+	font-style: var(--pullquote--font-style);
 	letter-spacing: var(--heading--letter-spacing-h4);
-	line-height: var(--heading--line-height);
+	line-height: var(--pullquote--line-height);
+	margin: 0;
 }
 
 .wp-block-pullquote a {
@@ -2222,16 +2222,13 @@ p.has-background {
 .wp-block-pullquote cite,
 .wp-block-pullquote footer {
 	color: currentColor;
-	font-size: var(--global--font-size-sm);
 	display: block;
+	font-size: var(--global--font-size-xs);
+	text-transform: none;
 }
 
 .wp-block-pullquote:not(.is-style-solid-color) {
 	background: none;
-}
-
-.wp-block-pullquote:not(.is-style-solid-color) blockquote {
-	padding-left: 0;
 }
 
 .wp-block-pullquote.is-style-default.alignleft blockquote > *, .wp-block-pullquote.is-style-default.aligncenter blockquote > *, .wp-block-pullquote.is-style-default.alignright blockquote > * {
@@ -2242,17 +2239,26 @@ p.has-background {
 	border-left-color: var(--quote--border-color);
 	border-left-style: solid;
 	border-left-width: var(--quote--border-width);
-	padding-left: var(--global--spacing-horizontal);
+	font-style: normal;
+}
+
+.wp-block-pullquote.alignwide > p,
+.wp-block-pullquote.alignwide blockquote {
+	max-width: var(--responsive--alignwide-width);
+}
+
+.wp-block-pullquote.alignfull:not(.is-style-solid-color) > p,
+.wp-block-pullquote.alignfull:not(.is-style-solid-color) blockquote {
+	padding: 0 calc( 2 * var(--global--spacing-unit));
 }
 
 .wp-block-pullquote.is-style-solid-color {
 	background-color: var(--pullquote--color-foreground);
 	color: var(--pullquote--color-background);
+	padding: calc( 2 * var(--global--spacing-unit));
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
-	padding-left: var(--global--spacing-unit);
-	padding-right: var(--global--spacing-unit);
 	max-width: inherit;
 }
 
@@ -2260,14 +2266,6 @@ p.has-background {
 .wp-block-pullquote.is-style-solid-color cite,
 .wp-block-pullquote.is-style-solid-color footer {
 	color: currentColor;
-}
-
-.wp-block-pullquote.alignwide > p,
-.wp-block-pullquote.alignfull > p,
-.wp-block-pullquote.alignwide blockquote,
-.wp-block-pullquote.alignfull blockquote {
-	margin-left: auto;
-	margin-right: auto;
 }
 
 .wp-block-quote {
@@ -2296,14 +2294,14 @@ p.has-background {
 .wp-block-quote p {
 	font-family: var(--quote--font-family);
 	font-size: var(--quote--font-size);
-	line-height: var(--heading--line-height);
+	line-height: var(--global--line-height-body);
 }
 
 .wp-block-quote .wp-block-quote__citation,
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--global--color-foreground-light);
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
@@ -2327,20 +2325,29 @@ p.has-background {
 	color: currentColor;
 }
 
-.wp-block-quote[style*="text-align:right"], .wp-block-quote[style*="text-align: right"] {
-	border-right-color: var(--quote--border-color);
+.wp-block-quote.has-text-align-right {
+	border-right: var(--quote--border-width) solid var(--quote--border-color);
 }
 
 .wp-block-quote.is-style-large, .wp-block-quote.is-large {
+	border-left: var(--quote--border-width) solid var(--quote--border-color);
+	padding-left: var(--global--spacing-horizontal);
 	/* Resetting margins to match _block-container.scss */
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
-	padding: 0;
 }
 
 .wp-block-quote.is-style-large p, .wp-block-quote.is-large p {
 	font-size: var(--quote--font-size-large);
-	line-height: var(--heading--line-height);
+	font-style: normal;
+}
+
+.wp-block-quote.is-style-large.has-text-align-right, .wp-block-quote.is-large.has-text-align-right {
+	border-left: none;
+}
+
+.wp-block-quote.is-style-large.has-text-align-center, .wp-block-quote.is-large.has-text-align-center {
+	border: none;
 }
 
 .wp-block-quote.is-style-large .wp-block-quote__citation,
@@ -2349,7 +2356,7 @@ p.has-background {
 .wp-block-quote.is-large cite,
 .wp-block-quote.is-large footer {
 	color: var(--global--color-foreground-light);
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote,

--- a/varya/style.css
+++ b/varya/style.css
@@ -2813,8 +2813,14 @@ table th,
 }
 
 .site-title a {
+	background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);
+	background-position: 0 1.22em;
+	background-repeat: repeat-x;
+	background-size: 8px 2px;
+	border-bottom: none;
 	color: currentColor;
 	font-weight: var(--branding--title--font-weight);
+	text-shadow: 1px 0px var(--global--color-background), -1px 0px var(--global--color-background), -2px 0px var(--global--color-background), 2px 0px var(--global--color-background), -3px 0px var(--global--color-background), 3px 0px var(--global--color-background), -4px 0px var(--global--color-background), 4px 0px var(--global--color-background), -5px 0px var(--global--color-background), 5px 0px var(--global--color-background);
 }
 
 .site-title a:link, .site-title a:visited {
@@ -2823,6 +2829,10 @@ table th,
 
 .site-title a:hover {
 	color: var(--branding--color-link-hover);
+}
+
+.site-title a::selection {
+	text-shadow: 1px 0px var(--global--color-text-selection), -1px 0px var(--global--color-text-selection), -2px 0px var(--global--color-text-selection), 2px 0px var(--global--color-text-selection), -3px 0px var(--global--color-text-selection), 3px 0px var(--global--color-text-selection), -4px 0px var(--global--color-text-selection), 4px 0px var(--global--color-text-selection), -5px 0px var(--global--color-text-selection), 5px 0px var(--global--color-text-selection);
 }
 
 .site-description {

--- a/varya/style.css
+++ b/varya/style.css
@@ -3321,6 +3321,12 @@ nav a {
 	margin-right: calc(0.25 * var(--global--spacing-unit));
 }
 
+.site-main > article > .entry-footer {
+	margin-top: calc( var(--global--spacing-vertical) * 3);
+	padding-top: var(--global--spacing-unit);
+	border-top: var(--separator--height) solid var(--separator--border-color);
+}
+
 /**
  * Post Thumbnails
  */
@@ -3382,15 +3388,15 @@ nav a {
 }
 
 .post-navigation .meta-nav {
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 	line-height: var(--global--line-height-body);
+	color: var(--global--color-foreground);
 }
 
 .post-navigation .post-title {
 	font-family: var(--global--font-primary);
 	font-size: var(--global--font-size-lg);
 	line-height: var(--heading--line-height);
-	font-weight: 600;
 }
 
 @media only screen and (min-width: 482px) {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2816,7 +2816,7 @@ table th,
 	font-size: var(--branding--title--font-size);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
-	margin-bottom: var(--global--spacing-vertical);
+	margin-bottom: calc( var(--global--spacing-vertical) / 2);
 }
 
 .site-title a {
@@ -2872,7 +2872,7 @@ nav a {
 .main-navigation {
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	margin-top: var(--global--spacing-vertical);
+	margin-top: calc( var(--global--spacing-vertical) * 1.5);
 }
 
 .main-navigation > div {

--- a/varya/style.css
+++ b/varya/style.css
@@ -1798,37 +1798,37 @@ h6 strong, .h6 strong {
 h1, .h1 {
 	font-size: var(--heading--font-size-h1);
 	letter-spacing: var(--heading--letter-spacing-h1);
-	line-height: var(--heading--line-height);
+	line-height: var(--wp--typography--line-height, --heading--line-height);
 }
 
 h2, .h2 {
 	font-size: var(--heading--font-size-h2);
 	letter-spacing: var(--heading--letter-spacing-h2);
-	line-height: var(--heading--line-height);
+	line-height: var(--wp--typography--line-height, --heading--line-height);
 }
 
 h3, .h3 {
 	font-size: var(--heading--font-size-h3);
 	letter-spacing: var(--heading--letter-spacing-h3);
-	line-height: var(--heading--line-height);
+	line-height: var(--wp--typography--line-height, --heading--line-height);
 }
 
 h4, .h4 {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
-	line-height: var(--heading--line-height);
+	line-height: var(--wp--typography--line-height, --heading--line-height);
 }
 
 h5, .h5 {
 	font-size: var(--heading--font-size-h5);
 	letter-spacing: var(--heading--letter-spacing-h5);
-	line-height: var(--global--line-height-body);
+	line-height: var(--wp--typography--line-height, --global--line-height-body);
 }
 
 h6, .h6 {
 	font-size: var(--heading--font-size-h6);
 	letter-spacing: var(--heading--letter-spacing-h6);
-	line-height: var(--global--line-height-body);
+	line-height: var(--wp--typography--line-height, --global--line-height-body);
 }
 
 .wp-block-image {
@@ -2121,6 +2121,10 @@ dd {
 		padding-top: var(--global--spacing-vertical);
 		padding-bottom: var(--global--spacing-vertical);
 	}
+}
+
+p {
+	line-height: var(--wp--typography--line-height, --global--line-height-body);
 }
 
 p.has-background {

--- a/varya/style.css
+++ b/varya/style.css
@@ -3012,8 +3012,24 @@ nav a {
 	width: 100%;
 }
 
-.main-navigation a {
+.main-navigation .main-menu > .menu-item:hover > a {
+	color: var(--primary-nav--color-link-hover);
+}
+
+.main-navigation .main-menu > .menu-item:hover > a + svg {
+	fill: var(--primary-nav--color-link-hover);
+}
+
+.main-navigation .menu-item > a {
 	color: var(--primary-nav--color-link);
+}
+
+.main-navigation .menu-item > a:hover {
+	color: var(--primary-nav--color-link-hover);
+}
+
+.main-navigation a {
+	color: currentColor;
 	display: block;
 	font-family: var(--primary-nav--font-family);
 	font-weight: var(--primary-nav--font-weight);
@@ -3026,12 +3042,8 @@ nav a {
 	}
 }
 
-.main-navigation a:link, .main-navigation a:visited {
-	color: var(--primary-nav--color-link);
-}
-
-.main-navigation a:hover {
-	color: var(--primary-nav--color-link-hover);
+.main-navigation a:hover, .main-navigation a:link, .main-navigation a:visited {
+	color: currentColor;
 }
 
 .main-navigation .sub-menu {
@@ -3045,12 +3057,13 @@ nav a {
 }
 
 @media only screen and (min-width: 482px) {
-	.main-navigation > div > ul > .menu-item-has-children > a::after {
-		content: "\00a0\25BC";
+	.main-navigation .menu-item-has-children > a {
+		padding-right: 0;
+	}
+	.main-navigation .menu-item-has-children > .svg-icon {
 		display: inline-block;
-		font-size: var(--global--font-size-xs);
-		height: inherit;
-		width: inherit;
+		height: 100%;
+		margin-right: var(--primary-nav--padding);
 	}
 }
 


### PR DESCRIPTION
While this works, and addresses both the frontend and backend pretty well. I’m not sure it’s the best approach. 

Demo: https://cloudup.com/cyNcpgnlaSp

**ToDo**
- [x] Audit line-height variable overrides to make sure it works consistently for gutenberg and doesn’t negatively impact non-gutenberg variables.
- [x] Consider how child-themes might be impacted by this change.
- [ ] Look into setting a default line-height for headings and paragraphs. The editor shows a `1.5` line-height by default despite what the CSS actually has as the default before changing the option.


