### PR TITLE
Varya: Minor header cleanup

### DIFF
--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -155,8 +155,8 @@
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
-	--branding--logo--max-width: 128px;
-	--branding--logo--max-height: 128px;
+	--branding--logo--max-width: 120px;
+	--branding--logo--max-height: 120px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -155,8 +155,8 @@
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
-	--branding--logo--max-width: 128px;
-	--branding--logo--max-height: 128px;
+	--branding--logo--max-width: 120px;
+	--branding--logo--max-height: 120px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -9,8 +9,8 @@
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
 
-	--branding--logo--max-width: 128px;
-	--branding--logo--max-height: 128px;
+	--branding--logo--max-width: 120px;
+	--branding--logo--max-height: 120px;
 
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -20,7 +20,7 @@
 	font-size: var(--branding--title--font-size);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
-	margin-bottom: var(--global--spacing-vertical);
+	margin-bottom: calc( var(--global--spacing-vertical) / 2 );
 
 	a {
 		background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -4,7 +4,7 @@
 
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	margin-top: var(--global--spacing-vertical);
+	margin-top: calc( var(--global--spacing-vertical) * 1.5 );
 
 	// Menu wrapper
 	& > div {

--- a/varya/functions.php
+++ b/varya/functions.php
@@ -85,8 +85,8 @@ if ( ! function_exists( 'varya_setup' ) ) :
 		add_theme_support(
 			'custom-logo',
 			array(
-				'height'      => 128,
-				'width'       => 128,
+				'height'      => 120,
+				'width'       => 120,
 				'flex-width'  => false,
 				'flex-height' => false,
 			)

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2784,7 +2784,7 @@ table th,
 	font-size: var(--branding--title--font-size);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
-	margin-bottom: var(--global--spacing-vertical);
+	margin-bottom: calc( var(--global--spacing-vertical) / 2);
 }
 
 .site-title a {
@@ -2840,7 +2840,7 @@ nav a {
 .main-navigation {
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	margin-top: var(--global--spacing-vertical);
+	margin-top: calc( var(--global--spacing-vertical) * 1.5);
 }
 
 .main-navigation > div {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2809,7 +2809,7 @@ table th,
 	font-size: var(--branding--title--font-size);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
-	margin-bottom: var(--global--spacing-vertical);
+	margin-bottom: calc( var(--global--spacing-vertical) / 2);
 }
 
 .site-title a {
@@ -2865,7 +2865,7 @@ nav a {
 .main-navigation {
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	margin-top: var(--global--spacing-vertical);
+	margin-top: calc( var(--global--spacing-vertical) * 1.5);
 }
 
 .main-navigation > div {


### PR DESCRIPTION
This PR just does some very minor header adjustments to sync up better with the original design comps. 

- Changes the site logo size to 120x120 instead of 128x128 (Whoops)
- Moves the site description up just a bit, and moves the menu down just a bit. 

---

Before: 

![Screen Shot 2020-04-02 at 8 54 25 PM](https://user-images.githubusercontent.com/1202812/78313255-24821a00-7524-11ea-9f06-7bfb498b189d.png)

After:

![Screen Shot 2020-04-02 at 8 51 17 PM](https://user-images.githubusercontent.com/1202812/78313210-087e7880-7524-11ea-902c-8daef1923d59.png)

Comparison: 
 
![Frame 1](https://user-images.githubusercontent.com/1202812/78313373-82166680-7524-11ea-804a-e37d77c14ae7.png)
