### PR TITLE
Varya: Minor font + entry footer cleanup

### DIFF
--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -26,7 +26,7 @@ body {
 	--global--font-size-ratio: 1.2;
 	--global--font-size-base: 1em;
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -176,7 +176,7 @@
 	--entry-header--font-family: var(--heading--font-family);
 	--entry-header--font-size: var(--heading--font-size-h2);
 	--entry-content--font-family: var(--heading--font-size-h2);
-	--entry-meta--color: var(--global--color-foreground-light);
+	--entry-meta--color: var(--global--color-foreground);
 	--entry-meta--color-link: currentColor;
 	--entry-meta--color-hover: var(--global--color-primary-hover);
 	--entry-meta--font-family: var(--global--font-primary);

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -180,7 +180,7 @@
 	--entry-meta--color-link: currentColor;
 	--entry-meta--color-hover: var(--global--color-primary-hover);
 	--entry-meta--font-family: var(--global--font-primary);
-	--entry-meta--font-size: var(--global--font-size-sm);
+	--entry-meta--font-size: var(--global--font-size-xs);
 	--entry-author-bio--font-family: var(--heading--font-family);
 	--entry-author-bio--font-size: var(--heading--font-size-h3);
 	--footer--color-text: var(--global--color-foreground-light);

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -26,7 +26,7 @@
 	--global--font-size-ratio: 1.2;
 	--global--font-size-base: 1em;
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -18,7 +18,7 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--font-size-ratio: #{$typescale-ratio};
 	--global--font-size-base: #{$typescale-base};
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -26,7 +26,7 @@ body {
 	--global--font-size-ratio: 1.2;
 	--global--font-size-base: 1em;
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -176,7 +176,7 @@
 	--entry-header--font-family: var(--heading--font-family);
 	--entry-header--font-size: var(--heading--font-size-h2);
 	--entry-content--font-family: var(--heading--font-size-h2);
-	--entry-meta--color: var(--global--color-foreground-light);
+	--entry-meta--color: var(--global--color-foreground);
 	--entry-meta--color-link: currentColor;
 	--entry-meta--color-hover: var(--global--color-primary-hover);
 	--entry-meta--font-family: var(--global--font-primary);

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -180,7 +180,7 @@
 	--entry-meta--color-link: currentColor;
 	--entry-meta--color-hover: var(--global--color-primary-hover);
 	--entry-meta--font-family: var(--global--font-primary);
-	--entry-meta--font-size: var(--global--font-size-sm);
+	--entry-meta--font-size: var(--global--font-size-xs);
 	--entry-author-bio--font-family: var(--heading--font-family);
 	--entry-author-bio--font-size: var(--heading--font-size-h3);
 	--footer--color-text: var(--global--color-foreground-light);

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -26,7 +26,7 @@
 	--global--font-size-ratio: 1.2;
 	--global--font-size-base: 1em;
 	--global--font-size-xs: 14px;
-	--global--font-size-sm: 15px;
+	--global--font-size-sm: 16px;
 	--global--font-size-md: 18px;
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;

--- a/varya/assets/sass/components/entry/_config.scss
+++ b/varya/assets/sass/components/entry/_config.scss
@@ -11,7 +11,7 @@
 	--entry-meta--color-link: currentColor;
 	--entry-meta--color-hover: var(--global--color-primary-hover);
 	--entry-meta--font-family: var(--global--font-primary);
-	--entry-meta--font-size: var(--global--font-size-sm);
+	--entry-meta--font-size: var(--global--font-size-xs);
 
 	--entry-author-bio--font-family: var(--heading--font-family);
 	--entry-author-bio--font-size: var(--heading--font-size-h3);

--- a/varya/assets/sass/components/entry/_config.scss
+++ b/varya/assets/sass/components/entry/_config.scss
@@ -7,7 +7,7 @@
 
 	--entry-content--font-family: var(--heading--font-size-h2);
 
-	--entry-meta--color: var(--global--color-foreground-light);
+	--entry-meta--color: var(--global--color-foreground);
 	--entry-meta--color-link: currentColor;
 	--entry-meta--color-hover: var(--global--color-primary-hover);
 	--entry-meta--font-family: var(--global--font-primary);

--- a/varya/assets/sass/components/entry/_meta.scss
+++ b/varya/assets/sass/components/entry/_meta.scss
@@ -45,10 +45,9 @@
 	}
 }
 
-.entry-meta {
-
-}
-
-.entry-footer {
-
+// Extra specificity to override rules in _vertical-margins.scss
+.site-main > article > .entry-footer {
+	margin-top: calc( var(--global--spacing-vertical) * 3 );
+	padding-top: var(--global--spacing-unit);
+	border-top: var(--separator--height) solid var(--separator--border-color);
 }

--- a/varya/assets/sass/components/pagination/_style.scss
+++ b/varya/assets/sass/components/pagination/_style.scss
@@ -45,15 +45,15 @@
 .post-navigation {
 
 	.meta-nav {
-		font-size: var(--global--font-size-sm);
+		font-size: var(--global--font-size-xs);
 		line-height: var(--global--line-height-body);
+		color: var(--global--color-foreground);
 	}
 
 	.post-title {
 		font-family: var(--global--font-primary);
 		font-size: var(--global--font-size-lg);
 		line-height: var(--heading--line-height);
-		font-weight: 600;
 	}
 
 	.nav-links {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3296,6 +3296,12 @@ nav a {
 	margin-left: calc(0.25 * var(--global--spacing-unit));
 }
 
+.site-main > article > .entry-footer {
+	margin-top: calc( var(--global--spacing-vertical) * 3);
+	padding-top: var(--global--spacing-unit);
+	border-top: var(--separator--height) solid var(--separator--border-color);
+}
+
 /**
  * Post Thumbnails
  */

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3357,15 +3357,15 @@ nav a {
 }
 
 .post-navigation .meta-nav {
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 	line-height: var(--global--line-height-body);
+	color: var(--global--color-foreground);
 }
 
 .post-navigation .post-title {
 	font-family: var(--global--font-primary);
 	font-size: var(--global--font-size-lg);
 	line-height: var(--heading--line-height);
-	font-weight: 600;
 }
 
 @media only screen and (min-width: 482px) {

--- a/varya/style.css
+++ b/varya/style.css
@@ -3321,6 +3321,12 @@ nav a {
 	margin-right: calc(0.25 * var(--global--spacing-unit));
 }
 
+.site-main > article > .entry-footer {
+	margin-top: calc( var(--global--spacing-vertical) * 3);
+	padding-top: var(--global--spacing-unit);
+	border-top: var(--separator--height) solid var(--separator--border-color);
+}
+
 /**
  * Post Thumbnails
  */

--- a/varya/style.css
+++ b/varya/style.css
@@ -3382,15 +3382,15 @@ nav a {
 }
 
 .post-navigation .meta-nav {
-	font-size: var(--global--font-size-sm);
+	font-size: var(--global--font-size-xs);
 	line-height: var(--global--line-height-body);
+	color: var(--global--color-foreground);
 }
 
 .post-navigation .post-title {
 	font-family: var(--global--font-primary);
 	font-size: var(--global--font-size-lg);
 	line-height: var(--heading--line-height);
-	font-weight: 600;
 }
 
 @media only screen and (min-width: 482px) {


### PR DESCRIPTION
This takes care of a few miscellaneous things: 

- Adjusts the `--global--font-size-sm` font size from `15px` to `16px` to match the comps. 
- Removes bold weight from the post navigation. 
- Makes the post meta font size smaller to match the comps.
- Adjusts the spacing of the post footer to match the comps, adds a top border. 

---

Before: 

![Screen Shot 2020-04-02 at 10 30 28 PM](https://user-images.githubusercontent.com/1202812/78317920-957bfe80-7531-11ea-95ad-a82d7edad8df.png)

After: 

![Screen Shot 2020-04-02 at 10 30 09 PM](https://user-images.githubusercontent.com/1202812/78317922-9876ef00-7531-11ea-9c98-134eefdd88af.png)
