### PR TITLE
Varya: Clean up the header on mobile

### DIFF
--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -153,12 +153,15 @@
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--heading--font-size-h1);
+	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--logo--max-width: 128px;
 	--branding--logo--max-height: 128px;
+	--branding--logo--max-width-mobile: 96px;
+	--branding--logo--max-height-mobile: 96px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -153,12 +153,15 @@
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--heading--font-size-h1);
+	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--logo--max-width: 128px;
 	--branding--logo--max-height: 128px;
+	--branding--logo--max-width-mobile: 96px;
+	--branding--logo--max-height-mobile: 96px;
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;
 	--primary-nav--font-weight: normal;

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -4,6 +4,7 @@
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
 	--branding--title--font-size: var(--heading--font-size-h1);
+	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) ); // This is a one-off calculation.
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);
@@ -11,6 +12,8 @@
 
 	--branding--logo--max-width: 128px;
 	--branding--logo--max-height: 128px;
+	--branding--logo--max-width-mobile: 96px;
+	--branding--logo--max-height-mobile: 96px;
 
 	--primary-nav--font-family: var(--global--font-secondary);
 	--primary-nav--font-size: 16px;

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -20,7 +20,7 @@
 		background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);
 		background-position: 0 1.22em;
 		background-repeat: repeat-x;
-		background-size: 8px 2px;
+		background-size: 8px 1.5px;
 		border-bottom: none;
 		color: currentColor;
 		font-weight: var(--branding--title--font-weight);
@@ -62,6 +62,10 @@
 
 	@include media(mobile) {
 		font-size: var(--branding--title--font-size);
+
+		a {
+			background-size: 8px 2px;
+		}
 	}
 }
 
@@ -97,8 +101,6 @@ nav a {
 
 	@include media(mobile) {
 	
-		margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
-
 		.custom-logo {
 			max-width: var(--branding--logo--max-width);
 			max-height: var(--branding--logo--max-height);

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -1,9 +1,3 @@
-// Site logo
-
-.site-logo {
-
-}
-
 // Site branding
 
 .site-branding {

--- a/varya/assets/sass/components/header/_header-branding.scss
+++ b/varya/assets/sass/components/header/_header-branding.scss
@@ -11,7 +11,7 @@
 
 	color: var(--branding--color-link);
 	font-family: var(--branding--title--font-family);
-	font-size: var(--branding--title--font-size);
+	font-size: var(--branding--title--font-size-mobile);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
 	margin-bottom: var(--global--spacing-vertical);
@@ -60,6 +60,9 @@
 		}
 	}
 
+	@include media(mobile) {
+		font-size: var(--branding--title--font-size);
+	}
 }
 
 // Site description
@@ -83,11 +86,23 @@ nav a {
 // Site logo
 
 .site-logo {
-	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+
+	margin: calc( var(--global--spacing-vertical) / 2 ) var(--global--spacing-horizontal);
 
 	.custom-logo {
-		max-width: var(--branding--logo--max-width);
-		max-height: var(--branding--logo--max-height);
+		max-width: var(--branding--logo--max-width-mobile);
+		max-height: var(--branding--logo--max-height-mobile);
 		height: auto;
+	}
+
+	@include media(mobile) {
+	
+		margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+
+		.custom-logo {
+			max-width: var(--branding--logo--max-width);
+			max-height: var(--branding--logo--max-height);
+			height: auto;
+		}
 	}
 }

--- a/varya/assets/sass/structure/_vertical-margins.scss
+++ b/varya/assets/sass/structure/_vertical-margins.scss
@@ -27,8 +27,13 @@
 }
 
 .site-header {
-	padding-top: calc(3 * var(--global--spacing-vertical));
-	padding-bottom: calc(3 * var(--global--spacing-vertical));
+	padding-top: calc(2 * var(--global--spacing-vertical));
+	padding-bottom: calc(2 * var(--global--spacing-vertical));
+
+	@include media(mobile) {
+		padding-top: calc(3 * var(--global--spacing-vertical));
+		padding-bottom: calc(3 * var(--global--spacing-vertical));
+	}
 }
 
 /**

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2788,7 +2788,7 @@ table th,
 .site-title {
 	color: var(--branding--color-link);
 	font-family: var(--branding--title--font-family);
-	font-size: var(--branding--title--font-size);
+	font-size: var(--branding--title--font-size-mobile);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
 	margin-bottom: var(--global--spacing-vertical);
@@ -2817,6 +2817,12 @@ table th,
 	text-shadow: -1px 0px var(--global--color-text-selection), 1px 0px var(--global--color-text-selection), 2px 0px var(--global--color-text-selection), -2px 0px var(--global--color-text-selection), 3px 0px var(--global--color-text-selection), -3px 0px var(--global--color-text-selection), 4px 0px var(--global--color-text-selection), -4px 0px var(--global--color-text-selection), 5px 0px var(--global--color-text-selection), -5px 0px var(--global--color-text-selection);
 }
 
+@media only screen and (min-width: 482px) {
+	.site-title {
+		font-size: var(--branding--title--font-size);
+	}
+}
+
 .site-description {
 	color: currentColor;
 	font-family: var(--branding--description--font-family);
@@ -2835,13 +2841,24 @@ nav a {
 }
 
 .site-logo {
-	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+	margin: calc( var(--global--spacing-vertical) / 2) var(--global--spacing-horizontal);
 }
 
 .site-logo .custom-logo {
-	max-width: var(--branding--logo--max-width);
-	max-height: var(--branding--logo--max-height);
+	max-width: var(--branding--logo--max-width-mobile);
+	max-height: var(--branding--logo--max-height-mobile);
 	height: auto;
+}
+
+@media only screen and (min-width: 482px) {
+	.site-logo {
+		margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+	}
+	.site-logo .custom-logo {
+		max-width: var(--branding--logo--max-width);
+		max-height: var(--branding--logo--max-height);
+		height: auto;
+	}
 }
 
 .main-navigation {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2805,7 +2805,7 @@ table th,
 	background-image: linear-gradient(to left, var(--global--color-secondary) 100%, transparent 100%);
 	background-position: 100% 1.22em;
 	background-repeat: repeat-x;
-	background-size: 8px 2px;
+	background-size: 8px 1.5px;
 	border-bottom: none;
 	color: currentColor;
 	font-weight: var(--branding--title--font-weight);
@@ -2827,6 +2827,9 @@ table th,
 @media only screen and (min-width: 482px) {
 	.site-title {
 		font-size: var(--branding--title--font-size);
+	}
+	.site-title a {
+		background-size: 8px 2px;
 	}
 }
 
@@ -2858,9 +2861,6 @@ nav a {
 }
 
 @media only screen and (min-width: 482px) {
-	.site-logo {
-		margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
-	}
 	.site-logo .custom-logo {
 		max-width: var(--branding--logo--max-width);
 		max-height: var(--branding--logo--max-height);

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -183,8 +183,15 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 }
 
 .site-header {
-	padding-top: calc(3 * var(--global--spacing-vertical));
-	padding-bottom: calc(3 * var(--global--spacing-vertical));
+	padding-top: calc(1.5 * var(--global--spacing-vertical));
+	padding-bottom: calc(1.5 * var(--global--spacing-vertical));
+}
+
+@media only screen and (min-width: 482px) {
+	.site-header {
+		padding-top: calc(3 * var(--global--spacing-vertical));
+		padding-bottom: calc(3 * var(--global--spacing-vertical));
+	}
 }
 
 /**

--- a/varya/style.css
+++ b/varya/style.css
@@ -2813,7 +2813,7 @@ table th,
 .site-title {
 	color: var(--branding--color-link);
 	font-family: var(--branding--title--font-family);
-	font-size: var(--branding--title--font-size);
+	font-size: var(--branding--title--font-size-mobile);
 	letter-spacing: normal;
 	line-height: var(--global--line-height-heading);
 	margin-bottom: var(--global--spacing-vertical);
@@ -2842,6 +2842,12 @@ table th,
 	text-shadow: 1px 0px var(--global--color-text-selection), -1px 0px var(--global--color-text-selection), -2px 0px var(--global--color-text-selection), 2px 0px var(--global--color-text-selection), -3px 0px var(--global--color-text-selection), 3px 0px var(--global--color-text-selection), -4px 0px var(--global--color-text-selection), 4px 0px var(--global--color-text-selection), -5px 0px var(--global--color-text-selection), 5px 0px var(--global--color-text-selection);
 }
 
+@media only screen and (min-width: 482px) {
+	.site-title {
+		font-size: var(--branding--title--font-size);
+	}
+}
+
 .site-description {
 	color: currentColor;
 	font-family: var(--branding--description--font-family);
@@ -2860,13 +2866,24 @@ nav a {
 }
 
 .site-logo {
-	margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+	margin: calc( var(--global--spacing-vertical) / 2) var(--global--spacing-horizontal);
 }
 
 .site-logo .custom-logo {
-	max-width: var(--branding--logo--max-width);
-	max-height: var(--branding--logo--max-height);
+	max-width: var(--branding--logo--max-width-mobile);
+	max-height: var(--branding--logo--max-height-mobile);
 	height: auto;
+}
+
+@media only screen and (min-width: 482px) {
+	.site-logo {
+		margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
+	}
+	.site-logo .custom-logo {
+		max-width: var(--branding--logo--max-width);
+		max-height: var(--branding--logo--max-height);
+		height: auto;
+	}
 }
 
 .main-navigation {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2830,7 +2830,7 @@ table th,
 	background-image: linear-gradient(to right, var(--global--color-secondary) 100%, transparent 100%);
 	background-position: 0 1.22em;
 	background-repeat: repeat-x;
-	background-size: 8px 2px;
+	background-size: 8px 1.5px;
 	border-bottom: none;
 	color: currentColor;
 	font-weight: var(--branding--title--font-weight);
@@ -2852,6 +2852,9 @@ table th,
 @media only screen and (min-width: 482px) {
 	.site-title {
 		font-size: var(--branding--title--font-size);
+	}
+	.site-title a {
+		background-size: 8px 2px;
 	}
 }
 
@@ -2883,9 +2886,6 @@ nav a {
 }
 
 @media only screen and (min-width: 482px) {
-	.site-logo {
-		margin: var(--global--spacing-vertical) var(--global--spacing-horizontal);
-	}
 	.site-logo .custom-logo {
 		max-width: var(--branding--logo--max-width);
 		max-height: var(--branding--logo--max-height);

--- a/varya/style.css
+++ b/varya/style.css
@@ -191,8 +191,15 @@ body[class*="woocommerce"] .entry-content > .woocommerce {
 }
 
 .site-header {
-	padding-top: calc(3 * var(--global--spacing-vertical));
-	padding-bottom: calc(3 * var(--global--spacing-vertical));
+	padding-top: calc(2 * var(--global--spacing-vertical));
+	padding-bottom: calc(2 * var(--global--spacing-vertical));
+}
+
+@media only screen and (min-width: 482px) {
+	.site-header {
+		padding-top: calc(3 * var(--global--spacing-vertical));
+		padding-bottom: calc(3 * var(--global--spacing-vertical));
+	}
 }
 
 /**


### PR DESCRIPTION
This PR tackles a few small cleanup tasks for the site header on small screens: 

- It implements a slightly smaller font size for the site title. 
- It adds a smaller site logo.
- It tightens the padding around the site header so it uses space more efficiently. 

(Might need to make sure this doesn't conflict with #45, whichever one gets merged in first.)

---

Before:

![dotorgthemes test_(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/1202812/78363573-f9321600-7589-11ea-9bf7-8d6567c79357.png)


After: 

![dotorgthemes test_(iPhone 6_7_8)](https://user-images.githubusercontent.com/1202812/78363567-f7685280-7589-11ea-93d8-1195e2a8421b.png)
