### PR TITLE
Varya: Add mobile navigation treatment

### DIFF
--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -167,6 +167,7 @@
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
 	--primary-nav--justify-content: center;
+	--primary-nav--icon-size: 24px;
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);
 	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -160,7 +160,12 @@
 	--branding--logo--max-width: 128px;
 	--branding--logo--max-height: 128px;
 	--primary-nav--font-family: var(--global--font-secondary);
-	--primary-nav--font-size: 16px;
+	--primary-nav--font-family-mobile: var(--global--font-primary);
+	--primary-nav--font-size: var(--global--font-size-sm);
+	--primary-nav--font-size-mobile: var(--global--font-size-xxl);
+	--primary-nav--font-size-sub-menu-mobile: var(--global--font-size-lg);
+	--primary-nav--font-style: normal;
+	--primary-nav--font-style-sub-menu-mobile: italic;
 	--primary-nav--font-weight: normal;
 	--primary-nav--color-link: var(--global--color-primary);
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -167,6 +167,7 @@
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
 	--primary-nav--justify-content: center;
+	--primary-nav--icon-size: 24px;
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);
 	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -160,7 +160,12 @@
 	--branding--logo--max-width: 128px;
 	--branding--logo--max-height: 128px;
 	--primary-nav--font-family: var(--global--font-secondary);
-	--primary-nav--font-size: 16px;
+	--primary-nav--font-family-mobile: var(--global--font-primary);
+	--primary-nav--font-size: var(--global--font-size-sm);
+	--primary-nav--font-size-mobile: var(--global--font-size-xxl);
+	--primary-nav--font-size-sub-menu-mobile: var(--global--font-size-lg);
+	--primary-nav--font-style: normal;
+	--primary-nav--font-style-sub-menu-mobile: italic;
 	--primary-nav--font-weight: normal;
 	--primary-nav--color-link: var(--global--color-primary);
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -13,7 +13,12 @@
 	--branding--logo--max-height: 128px;
 
 	--primary-nav--font-family: var(--global--font-secondary);
-	--primary-nav--font-size: 16px;
+	--primary-nav--font-family-mobile: var(--global--font-primary);
+	--primary-nav--font-size: var(--global--font-size-sm);
+	--primary-nav--font-size-mobile: var(--global--font-size-xxl);
+	--primary-nav--font-size-sub-menu-mobile: var(--global--font-size-lg);
+	--primary-nav--font-style: normal;
+	--primary-nav--font-style-sub-menu-mobile: italic;
 	--primary-nav--font-weight: normal;
 	--primary-nav--color-link: var(--global--color-primary);
 	--primary-nav--color-link-hover: var(--global--color-primary-hover);

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -20,6 +20,7 @@
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
 	--primary-nav--justify-content: center;
+	--primary-nav--icon-size: 24px;
 
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -1,7 +1,6 @@
 // Navigation
 
 .main-navigation {
-
 	position: absolute;
 	top: 0;
 	right: 0;
@@ -55,11 +54,6 @@
 		z-index: 499;
 		transition: all .15s ease-in-out;
 	  	transform: translateY(var(--global--spacing-vertical));
-
-		// Logged-in position
-		.admin-bar & {
-			top: 46px;
-		}
 	}
 
 	// Checkbox hack
@@ -93,14 +87,10 @@
 	}
 
 	@include media(mobile) {
-
-		position: relative;
-		top: initial;
-		right: initial;
-		display: flex;
-		justify-content: var(--primary-nav--justify-content);
-		margin-top: calc( var(--global--spacing-vertical) * 1.5 );
-		padding: 0;
+		// Logged-in position
+		.admin-bar & {
+			top: 32px;
+		}
 
 		& > div {
 			display: inline-block;
@@ -117,6 +107,7 @@
 			padding: inherit;
 			background-color: transparent;
 			overflow: initial;
+			top: -46px;
 			z-index: 1;
 		}
 

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -10,6 +10,11 @@
 	margin-top: 0;
 	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
 
+	// Logged-in position
+	.admin-bar & {
+		top: 46px;
+	}
+
 	// Menu wrapper
 	& > div {
 		display: none;
@@ -54,6 +59,11 @@
 		overflow-x: hidden;
 		overflow-y: scroll;
 		z-index: 499;
+
+		// Logged-in position
+		.admin-bar & {
+			top: 46px;
+		}
 	}
 
 	#toggle:focus + #toggle-menu {
@@ -271,3 +281,5 @@
 		overflow: hidden;
 	}
 }
+
+

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -17,10 +17,12 @@
 
 	// Mobile menu toggle
 	#toggle-menu {
+		position: relative;
 		display: flex;
 		align-items: center;
 		justify-content: flex-end;
 		margin: 0;
+		z-index: 500;
 
 		&:hover {
 			color: var(--primary-nav--color-link-hover);
@@ -35,16 +37,22 @@
 	}
 
 	// Checkbox hack
+	#toggle:checked ~ #toggle-menu {
+		position: fixed;
+		right: var(--global--spacing-horizontal);
+	}
+
 	#toggle:checked ~ div:not(.woocommerce-menu-container) {
 		display: block;
-		top: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size));
+		position: fixed;
+		top: 0;
 		right: 0;
 		bottom: 0;
 		left: 0;
-		padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
+		padding: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 		background-color: var(--global--color-background);
-		position: fixed;
 		overflow: scroll;
+		z-index: 499;
 	}
 
 	#toggle:focus + #toggle-menu {

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -153,10 +153,10 @@
 
 		/* Sub-menus Flyout */
 		& > li > .sub-menu {
-			margin: 0;
 			position: relative;
 
 			@include media(mobile) {
+				margin: 0;
 				background: var(--global--color-background);
 				box-shadow: var(--global--elevation-4);
 				left: 0;
@@ -178,11 +178,15 @@
 	a {
 		color: var(--primary-nav--color-link);
 		display: block;
-		font-family: var(--primary-nav--font-family);
+		font-family: var(--primary-nav--font-family-mobile);
+		font-size: var(--primary-nav--font-size-mobile);
 		font-weight: var(--primary-nav--font-weight);
 		padding: calc(0.5 * var(--primary-nav--padding)) 0;
 
 		@include media(mobile) {
+			font-family: var(--primary-nav--font-family);
+			font-size: var(--primary-nav--font-size);
+			font-weight: var(--primary-nav--font-weight);
 			padding: var(--primary-nav--padding);
 		}
 
@@ -196,7 +200,7 @@
 		}
 	}
 
-	// Sub-menu depth indicators
+	// Sub-menu depth indicators + text styles
 	.sub-menu {
 
 		list-style: none;
@@ -204,9 +208,17 @@
 
 		.menu-item a {
 
+			font-size: var(--primary-nav--font-size-sub-menu-mobile);
+			font-style: var(--primary-nav--font-style-sub-menu-mobile);
 			padding-top: calc(0.5 * var(--primary-nav--padding));
 			padding-bottom: calc(0.5 * var(--primary-nav--padding));
+			
+			@include media(mobile) {
+				font-size: var(--primary-nav--font-size);
+				font-style: var(--primary-nav--font-style);
+			}
 		}
+
 	}
 
 	// Show top-level sub-menu indicators above mobile-breakpoint-only

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -233,9 +233,13 @@
 	}
 
 	// Show top-level sub-menu indicators above mobile-breakpoint-only
-	@include media(mobile) {
-		.menu-item-has-children {
+	.menu-item-has-children {
 
+		> .svg-icon {
+			display: none;
+		}
+
+		@include media(mobile) {
 			> a {
 				padding-right: 0;
 			}

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -51,7 +51,8 @@
 		left: 0;
 		padding: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 		background-color: var(--global--color-background);
-		overflow: scroll;
+		overflow-x: hidden;
+		overflow-y: scroll;
 		z-index: 499;
 	}
 

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -17,7 +17,8 @@
 
 	// Menu wrapper
 	& > div {
-		display: none;
+		visibility: hidden;
+		opacity: 0;
 	}
 
 	// Mobile menu toggle
@@ -41,14 +42,7 @@
 		}
 	}
 
-	// Checkbox hack
-	#toggle:checked ~ #toggle-menu {
-		position: fixed;
-		right: var(--global--spacing-horizontal);
-	}
-
-	#toggle:checked ~ div:not(.woocommerce-menu-container) {
-		display: block;
+	#toggle ~ div:not(.woocommerce-menu-container) {
 		position: fixed;
 		top: 0;
 		right: 0;
@@ -59,11 +53,25 @@
 		overflow-x: hidden;
 		overflow-y: scroll;
 		z-index: 499;
+		transition: all .15s ease-in-out;
+	  	transform: translateY(var(--global--spacing-vertical));
 
 		// Logged-in position
 		.admin-bar & {
 			top: 46px;
 		}
+	}
+
+	// Checkbox hack
+	#toggle:checked ~ #toggle-menu {
+		position: fixed;
+		right: var(--global--spacing-horizontal);
+	}
+
+	#toggle:checked ~ div:not(.woocommerce-menu-container) {
+		visibility: visible;
+		opacity: 1;
+		transform: translateY(0);
 	}
 
 	#toggle:focus + #toggle-menu {

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -100,13 +100,24 @@
 		display: flex;
 		justify-content: var(--primary-nav--justify-content);
 		margin-top: calc( var(--global--spacing-vertical) * 1.5 );
+		padding: 0;
 
 		& > div {
 			display: inline-block;
+			visibility: visible;
+			opacity: 1;
 		}
 
 		#toggle-menu {
 			display: none;
+		}
+
+		#toggle ~ div:not(.woocommerce-menu-container) {
+			position: relative;
+			padding: inherit;
+			background-color: transparent;
+			overflow: initial;
+			z-index: 1;
 		}
 
 		// Hide sub-sub-menus

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -2,10 +2,14 @@
 
 .main-navigation {
 
+	position: absolute;
+	top: 0;
+	right: 0;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	margin-top: var(--global--spacing-vertical);
-
+	margin-top: 0;
+	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
+	
 	// Menu wrapper
 	& > div {
 		display: none;
@@ -13,19 +17,38 @@
 
 	// Mobile menu toggle
 	#toggle-menu {
-		display: inline-block;
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
 		margin: 0;
+
+		&:hover {
+			color: var(--primary-nav--color-link-hover);
+		}
+
+		.dropdown-icon {
+			height: var(--primary-nav--icon-size);
+			width: var(--primary-nav--icon-size);
+			fill: currentColor;
+			margin-left: calc(0.5 * var(--global--spacing-unit));
+		}
 	}
 
 	// Checkbox hack
 	#toggle:checked ~ div:not(.woocommerce-menu-container) {
 		display: block;
+		top: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size));
+		right: 0;
+		bottom: 0;
+		left: 0;
+		padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
+		background-color: var(--global--color-background);
+		position: fixed;
+		overflow: scroll;
 	}
 
 	#toggle:focus + #toggle-menu {
-		background-color: var(--primary-nav--color-link-hover);
 		outline: inherit;
-		text-decoration: underline;
 	}
 
 	.dropdown-icon.close {
@@ -44,8 +67,12 @@
 
 	@include media(mobile) {
 
+		position: relative;
+		top: initial;
+		right: initial;
 		display: flex;
 		justify-content: var(--primary-nav--justify-content);
+		margin-top: var(--global--spacing-vertical);
 
 		& > div {
 			display: inline-block;

--- a/varya/classes/class-varya-svg-icons.php
+++ b/varya/classes/class-varya-svg-icons.php
@@ -174,6 +174,16 @@ class Varya_SVG_Icons {
 	<path d="M0 0h24v24H0z" fill="none"/>
 </svg>',
 
+		'menu_close' => /* custom  - menu close */ '
+		<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path fill-rule="evenodd" clip-rule="evenodd" d="M12.707 11.5l4.596-4.596-.707-.707L12 10.793 7.403 6.197l-.707.707 4.597 4.596-4.597 4.596.707.707L12 12.207l4.596 4.596.707-.707-4.596-4.596z" fill="currentColor"/>
+		</svg>',
+
+		'menu_open' => /* custom  - menu open */ '
+		<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path fill-rule="evenodd" clip-rule="evenodd" d="M5 5h14v1H5V5zm0 6h14v1H5v-1zm14 6H5v1h14v-1z" fill="currentColor"/>
+		</svg>',
+
 	);
 
 	/**

--- a/varya/header.php
+++ b/varya/header.php
@@ -30,10 +30,10 @@
 			<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
 				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main Navigation', 'varya' ); ?>">
 					<input type="checkbox" role="button" aria-haspopup="true" id="toggle" class="hide-visually">
-					<label for="toggle" id="toggle-menu" class="button">
+					<label for="toggle" id="toggle-menu">
 						<?php _e( 'Menu', 'varya' ); ?>
-						<span class="dropdown-icon open">+</span>
-						<span class="dropdown-icon close">&times;</span>
+						<span class="dropdown-icon open"><?php echo varya_get_icon_svg( 'menu_open' ) ?></span>
+						<span class="dropdown-icon close"><?php echo varya_get_icon_svg( 'menu_close' ) ?></span>
 						<span class="hide-visually expanded-text"><?php _e( 'expanded', 'varya' ); ?></span>
 						<span class="hide-visually collapsed-text"><?php _e( 'collapsed', 'varya' ); ?></span>
 					</label>

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2878,6 +2878,10 @@ nav a {
 	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
 }
 
+.admin-bar .main-navigation {
+	top: 46px;
+}
+
 .main-navigation > div {
 	display: none;
 }
@@ -2919,6 +2923,10 @@ nav a {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	z-index: 499;
+}
+
+.admin-bar .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+	top: 46px;
 }
 
 .main-navigation #toggle:focus + #toggle-menu {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2911,7 +2911,6 @@ nav a {
 		left: initial;
 		display: flex;
 		justify-content: var(--primary-nav--justify-content);
-		margin-top: var(--global--spacing-vertical);
 		margin-top: calc( var(--global--spacing-vertical) * 1.5);
 	}
 	.main-navigation > div {
@@ -3070,6 +3069,10 @@ nav a {
 		font-size: var(--primary-nav--font-size);
 		font-style: var(--primary-nav--font-style);
 	}
+}
+
+.main-navigation .menu-item-has-children > .svg-icon {
+	display: none;
 }
 
 @media only screen and (min-width: 482px) {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2883,7 +2883,8 @@ nav a {
 }
 
 .main-navigation > div {
-	display: none;
+	visibility: hidden;
+	opacity: 0;
 }
 
 .main-navigation #toggle-menu {
@@ -2906,13 +2907,7 @@ nav a {
 	margin-right: calc(0.5 * var(--global--spacing-unit));
 }
 
-.main-navigation #toggle:checked ~ #toggle-menu {
-	position: fixed;
-	left: var(--global--spacing-horizontal);
-}
-
-.main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
-	display: block;
+.main-navigation #toggle ~ div:not(.woocommerce-menu-container) {
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -2923,10 +2918,23 @@ nav a {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	z-index: 499;
+	transition: all .15s ease-in-out;
+	transform: translateY(var(--global--spacing-vertical));
 }
 
-.admin-bar .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+.admin-bar .main-navigation #toggle ~ div:not(.woocommerce-menu-container) {
 	top: 46px;
+}
+
+.main-navigation #toggle:checked ~ #toggle-menu {
+	position: fixed;
+	left: var(--global--spacing-horizontal);
+}
+
+.main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+	visibility: visible;
+	opacity: 1;
+	transform: translateY(0);
 }
 
 .main-navigation #toggle:focus + #toggle-menu {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2883,10 +2883,12 @@ nav a {
 }
 
 .main-navigation #toggle-menu {
+	position: relative;
 	display: flex;
 	align-items: center;
 	justify-content: flex-end;
 	margin: 0;
+	z-index: 500;
 }
 
 .main-navigation #toggle-menu:hover {
@@ -2900,16 +2902,21 @@ nav a {
 	margin-right: calc(0.5 * var(--global--spacing-unit));
 }
 
+.main-navigation #toggle:checked ~ #toggle-menu {
+	position: fixed;
+}
+
 .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
 	display: block;
-	top: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size));
+	position: fixed;
+	top: 0;
 	left: 0;
 	bottom: 0;
 	right: 0;
-	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
+	padding: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
-	position: fixed;
 	overflow: scroll;
+	z-index: 499;
 }
 
 .main-navigation #toggle:focus + #toggle-menu {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2922,10 +2922,6 @@ nav a {
 	transform: translateY(var(--global--spacing-vertical));
 }
 
-.admin-bar .main-navigation #toggle ~ div:not(.woocommerce-menu-container) {
-	top: 46px;
-}
-
 .main-navigation #toggle:checked ~ #toggle-menu {
 	position: fixed;
 	left: var(--global--spacing-horizontal);
@@ -2954,14 +2950,8 @@ nav a {
 }
 
 @media only screen and (min-width: 482px) {
-	.main-navigation {
-		position: relative;
-		top: initial;
-		left: initial;
-		display: flex;
-		justify-content: var(--primary-nav--justify-content);
-		margin-top: calc( var(--global--spacing-vertical) * 1.5);
-		padding: 0;
+	.admin-bar .main-navigation {
+		top: 32px;
 	}
 	.main-navigation > div {
 		display: inline-block;
@@ -2976,6 +2966,7 @@ nav a {
 		padding: inherit;
 		background-color: transparent;
 		overflow: initial;
+		top: -46px;
 		z-index: 1;
 	}
 	.main-navigation > div > ul > li > ul {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2904,6 +2904,7 @@ nav a {
 
 .main-navigation #toggle:checked ~ #toggle-menu {
 	position: fixed;
+	left: var(--global--spacing-horizontal);
 }
 
 .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
@@ -2915,7 +2916,8 @@ nav a {
 	right: 0;
 	padding: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
-	overflow: scroll;
+	overflow-x: hidden;
+	overflow-y: scroll;
 	z-index: 499;
 }
 

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2845,9 +2845,13 @@ nav a {
 }
 
 .main-navigation {
+	position: absolute;
+	top: 0;
+	left: 0;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	margin-top: var(--global--spacing-vertical);
+	margin-top: 0;
+	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
 }
 
 .main-navigation > div {
@@ -2855,18 +2859,37 @@ nav a {
 }
 
 .main-navigation #toggle-menu {
-	display: inline-block;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
 	margin: 0;
+}
+
+.main-navigation #toggle-menu:hover {
+	color: var(--primary-nav--color-link-hover);
+}
+
+.main-navigation #toggle-menu .dropdown-icon {
+	height: var(--primary-nav--icon-size);
+	width: var(--primary-nav--icon-size);
+	fill: currentColor;
+	margin-right: calc(0.5 * var(--global--spacing-unit));
 }
 
 .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
 	display: block;
+	top: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size));
+	left: 0;
+	bottom: 0;
+	right: 0;
+	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
+	background-color: var(--global--color-background);
+	position: fixed;
+	overflow: scroll;
 }
 
 .main-navigation #toggle:focus + #toggle-menu {
-	background-color: var(--primary-nav--color-link-hover);
 	outline: inherit;
-	text-decoration: underline;
 }
 
 .main-navigation .dropdown-icon.close {
@@ -2883,8 +2906,12 @@ nav a {
 
 @media only screen and (min-width: 482px) {
 	.main-navigation {
+		position: relative;
+		top: initial;
+		left: initial;
 		display: flex;
 		justify-content: var(--primary-nav--justify-content);
+		margin-top: var(--global--spacing-vertical);
 	}
 	.main-navigation > div {
 		display: inline-block;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2992,12 +2992,12 @@ nav a {
 }
 
 .main-navigation > div > ul > li > .sub-menu {
-	margin: 0;
 	position: relative;
 }
 
 @media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > li > .sub-menu {
+		margin: 0;
 		background: var(--global--color-background);
 		box-shadow: var(--global--elevation-4);
 		right: 0;
@@ -3017,13 +3017,17 @@ nav a {
 .main-navigation a {
 	color: var(--primary-nav--color-link);
 	display: block;
-	font-family: var(--primary-nav--font-family);
+	font-family: var(--primary-nav--font-family-mobile);
+	font-size: var(--primary-nav--font-size-mobile);
 	font-weight: var(--primary-nav--font-weight);
 	padding: calc(0.5 * var(--primary-nav--padding)) 0;
 }
 
 @media only screen and (min-width: 482px) {
 	.main-navigation a {
+		font-family: var(--primary-nav--font-family);
+		font-size: var(--primary-nav--font-size);
+		font-weight: var(--primary-nav--font-weight);
 		padding: var(--primary-nav--padding);
 	}
 }
@@ -3042,8 +3046,17 @@ nav a {
 }
 
 .main-navigation .sub-menu .menu-item a {
+	font-size: var(--primary-nav--font-size-sub-menu-mobile);
+	font-style: var(--primary-nav--font-style-sub-menu-mobile);
 	padding-top: calc(0.5 * var(--primary-nav--padding));
 	padding-bottom: calc(0.5 * var(--primary-nav--padding));
+}
+
+@media only screen and (min-width: 482px) {
+	.main-navigation .sub-menu .menu-item a {
+		font-size: var(--primary-nav--font-size);
+		font-style: var(--primary-nav--font-style);
+	}
 }
 
 @media only screen and (min-width: 482px) {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2961,12 +2961,22 @@ nav a {
 		display: flex;
 		justify-content: var(--primary-nav--justify-content);
 		margin-top: calc( var(--global--spacing-vertical) * 1.5);
+		padding: 0;
 	}
 	.main-navigation > div {
 		display: inline-block;
+		visibility: visible;
+		opacity: 1;
 	}
 	.main-navigation #toggle-menu {
 		display: none;
+	}
+	.main-navigation #toggle ~ div:not(.woocommerce-menu-container) {
+		position: relative;
+		padding: inherit;
+		background-color: transparent;
+		overflow: initial;
+		z-index: 1;
 	}
 	.main-navigation > div > ul > li > ul {
 		display: none;

--- a/varya/style.css
+++ b/varya/style.css
@@ -2908,7 +2908,8 @@ nav a {
 }
 
 .main-navigation > div {
-	display: none;
+	visibility: hidden;
+	opacity: 0;
 }
 
 .main-navigation #toggle-menu {
@@ -2931,13 +2932,7 @@ nav a {
 	margin-left: calc(0.5 * var(--global--spacing-unit));
 }
 
-.main-navigation #toggle:checked ~ #toggle-menu {
-	position: fixed;
-	right: var(--global--spacing-horizontal);
-}
-
-.main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
-	display: block;
+.main-navigation #toggle ~ div:not(.woocommerce-menu-container) {
 	position: fixed;
 	top: 0;
 	right: 0;
@@ -2948,10 +2943,23 @@ nav a {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	z-index: 499;
+	transition: all .15s ease-in-out;
+	transform: translateY(var(--global--spacing-vertical));
 }
 
-.admin-bar .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+.admin-bar .main-navigation #toggle ~ div:not(.woocommerce-menu-container) {
 	top: 46px;
+}
+
+.main-navigation #toggle:checked ~ #toggle-menu {
+	position: fixed;
+	right: var(--global--spacing-horizontal);
+}
+
+.main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+	visibility: visible;
+	opacity: 1;
+	transform: translateY(0);
 }
 
 .main-navigation #toggle:focus + #toggle-menu {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2870,9 +2870,13 @@ nav a {
 }
 
 .main-navigation {
+	position: absolute;
+	top: 0;
+	right: 0;
 	color: var(--primary-nav--color-text);
 	font-size: var(--primary-nav--font-size);
-	margin-top: var(--global--spacing-vertical);
+	margin-top: 0;
+	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
 }
 
 .main-navigation > div {
@@ -2880,18 +2884,37 @@ nav a {
 }
 
 .main-navigation #toggle-menu {
-	display: inline-block;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
 	margin: 0;
+}
+
+.main-navigation #toggle-menu:hover {
+	color: var(--primary-nav--color-link-hover);
+}
+
+.main-navigation #toggle-menu .dropdown-icon {
+	height: var(--primary-nav--icon-size);
+	width: var(--primary-nav--icon-size);
+	fill: currentColor;
+	margin-left: calc(0.5 * var(--global--spacing-unit));
 }
 
 .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
 	display: block;
+	top: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size));
+	right: 0;
+	bottom: 0;
+	left: 0;
+	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
+	background-color: var(--global--color-background);
+	position: fixed;
+	overflow: scroll;
 }
 
 .main-navigation #toggle:focus + #toggle-menu {
-	background-color: var(--primary-nav--color-link-hover);
 	outline: inherit;
-	text-decoration: underline;
 }
 
 .main-navigation .dropdown-icon.close {
@@ -2908,8 +2931,12 @@ nav a {
 
 @media only screen and (min-width: 482px) {
 	.main-navigation {
+		position: relative;
+		top: initial;
+		right: initial;
 		display: flex;
 		justify-content: var(--primary-nav--justify-content);
+		margin-top: var(--global--spacing-vertical);
 	}
 	.main-navigation > div {
 		display: inline-block;

--- a/varya/style.css
+++ b/varya/style.css
@@ -2908,10 +2908,12 @@ nav a {
 }
 
 .main-navigation #toggle-menu {
+	position: relative;
 	display: flex;
 	align-items: center;
 	justify-content: flex-end;
 	margin: 0;
+	z-index: 500;
 }
 
 .main-navigation #toggle-menu:hover {
@@ -2925,16 +2927,22 @@ nav a {
 	margin-left: calc(0.5 * var(--global--spacing-unit));
 }
 
+.main-navigation #toggle:checked ~ #toggle-menu {
+	position: fixed;
+	right: var(--global--spacing-horizontal);
+}
+
 .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
 	display: block;
-	top: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size));
+	position: fixed;
+	top: 0;
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
+	padding: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
-	position: fixed;
 	overflow: scroll;
+	z-index: 499;
 }
 
 .main-navigation #toggle:focus + #toggle-menu {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2986,12 +2986,22 @@ nav a {
 		display: flex;
 		justify-content: var(--primary-nav--justify-content);
 		margin-top: calc( var(--global--spacing-vertical) * 1.5);
+		padding: 0;
 	}
 	.main-navigation > div {
 		display: inline-block;
+		visibility: visible;
+		opacity: 1;
 	}
 	.main-navigation #toggle-menu {
 		display: none;
+	}
+	.main-navigation #toggle ~ div:not(.woocommerce-menu-container) {
+		position: relative;
+		padding: inherit;
+		background-color: transparent;
+		overflow: initial;
+		z-index: 1;
 	}
 	.main-navigation > div > ul > li > ul {
 		display: none;

--- a/varya/style.css
+++ b/varya/style.css
@@ -2947,10 +2947,6 @@ nav a {
 	transform: translateY(var(--global--spacing-vertical));
 }
 
-.admin-bar .main-navigation #toggle ~ div:not(.woocommerce-menu-container) {
-	top: 46px;
-}
-
 .main-navigation #toggle:checked ~ #toggle-menu {
 	position: fixed;
 	right: var(--global--spacing-horizontal);
@@ -2979,14 +2975,8 @@ nav a {
 }
 
 @media only screen and (min-width: 482px) {
-	.main-navigation {
-		position: relative;
-		top: initial;
-		right: initial;
-		display: flex;
-		justify-content: var(--primary-nav--justify-content);
-		margin-top: calc( var(--global--spacing-vertical) * 1.5);
-		padding: 0;
+	.admin-bar .main-navigation {
+		top: 32px;
 	}
 	.main-navigation > div {
 		display: inline-block;
@@ -3001,6 +2991,7 @@ nav a {
 		padding: inherit;
 		background-color: transparent;
 		overflow: initial;
+		top: -46px;
 		z-index: 1;
 	}
 	.main-navigation > div > ul > li > ul {

--- a/varya/style.css
+++ b/varya/style.css
@@ -3096,6 +3096,10 @@ nav a {
 	}
 }
 
+.main-navigation .menu-item-has-children > .svg-icon {
+	display: none;
+}
+
 @media only screen and (min-width: 482px) {
 	.main-navigation .menu-item-has-children > a {
 		padding-right: 0;

--- a/varya/style.css
+++ b/varya/style.css
@@ -3017,12 +3017,12 @@ nav a {
 }
 
 .main-navigation > div > ul > li > .sub-menu {
-	margin: 0;
 	position: relative;
 }
 
 @media only screen and (min-width: 482px) {
 	.main-navigation > div > ul > li > .sub-menu {
+		margin: 0;
 		background: var(--global--color-background);
 		box-shadow: var(--global--elevation-4);
 		left: 0;
@@ -3042,13 +3042,17 @@ nav a {
 .main-navigation a {
 	color: var(--primary-nav--color-link);
 	display: block;
-	font-family: var(--primary-nav--font-family);
+	font-family: var(--primary-nav--font-family-mobile);
+	font-size: var(--primary-nav--font-size-mobile);
 	font-weight: var(--primary-nav--font-weight);
 	padding: calc(0.5 * var(--primary-nav--padding)) 0;
 }
 
 @media only screen and (min-width: 482px) {
 	.main-navigation a {
+		font-family: var(--primary-nav--font-family);
+		font-size: var(--primary-nav--font-size);
+		font-weight: var(--primary-nav--font-weight);
 		padding: var(--primary-nav--padding);
 	}
 }
@@ -3067,8 +3071,17 @@ nav a {
 }
 
 .main-navigation .sub-menu .menu-item a {
+	font-size: var(--primary-nav--font-size-sub-menu-mobile);
+	font-style: var(--primary-nav--font-style-sub-menu-mobile);
 	padding-top: calc(0.5 * var(--primary-nav--padding));
 	padding-bottom: calc(0.5 * var(--primary-nav--padding));
+}
+
+@media only screen and (min-width: 482px) {
+	.main-navigation .sub-menu .menu-item a {
+		font-size: var(--primary-nav--font-size);
+		font-style: var(--primary-nav--font-style);
+	}
 }
 
 @media only screen and (min-width: 482px) {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2903,6 +2903,10 @@ nav a {
 	padding: var(--global--spacing-unit) var(--global--spacing-horizontal);
 }
 
+.admin-bar .main-navigation {
+	top: 46px;
+}
+
 .main-navigation > div {
 	display: none;
 }
@@ -2944,6 +2948,10 @@ nav a {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	z-index: 499;
+}
+
+.admin-bar .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+	top: 46px;
 }
 
 .main-navigation #toggle:focus + #toggle-menu {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2941,7 +2941,8 @@ nav a {
 	left: 0;
 	padding: calc(2* var(--global--spacing-unit) + var(--primary-nav--icon-size)) var(--global--spacing-unit) var(--global--spacing-horizontal);
 	background-color: var(--global--color-background);
-	overflow: scroll;
+	overflow-x: hidden;
+	overflow-y: scroll;
 	z-index: 499;
 }
 


### PR DESCRIPTION
This PR adds a small-screen menu treatment to match the design comps. Still a few things to do: 

- [x] Fix bug where the top of the screen is scrollable.
- [x] Adjust the position of the menu if the WP-Admin bar is visible. (Currently it gets hidden behind the bar).
- [x] Fix the horizontal scroll overflow.

... and probably some more bugs too!

---

Before: 

![mobile-menu-before](https://user-images.githubusercontent.com/1202812/78389315-8720f780-75b0-11ea-9144-96ccd0be3534.gif)


After: 

![mobile-menu](https://user-images.githubusercontent.com/1202812/78389319-88eabb00-75b0-11ea-85da-636c56e4b7a1.gif)
