### PR TITLE
Varya: Fix left/right-aligned Cover Block margin issue.

### DIFF
--- a/varya/assets/sass/blocks/cover/_style.scss
+++ b/varya/assets/sass/blocks/cover/_style.scss
@@ -75,6 +75,26 @@
 	/**
 	 * Block Options
 	 */
+	.entry-content > &.alignright {
+		@extend %responsive-alignleft-mobile;
+		@extend %responsive-alignleft;
+
+		margin-left: var(--global--spacing-horizontal);
+		@include media(mobile-only) {
+			margin-right: 0;
+		}
+	}
+
+	.entry-content > &.alignleft {
+		@extend %responsive-alignright-mobile;
+		@extend %responsive-alignright;
+
+		margin-right: var(--global--spacing-horizontal);
+		@include media(mobile-only) {
+			margin-left: 0;
+		}
+	}
+
 	&.alignleft,
 	&.alignright {
 		margin-top: 0;

--- a/varya/assets/sass/blocks/cover/_style.scss
+++ b/varya/assets/sass/blocks/cover/_style.scss
@@ -78,8 +78,8 @@
 	.entry-content > &.alignright {
 		@extend %responsive-alignleft-mobile;
 		@extend %responsive-alignleft;
-
 		margin-left: var(--global--spacing-horizontal);
+
 		@include media(mobile-only) {
 			margin-right: 0;
 		}
@@ -88,8 +88,8 @@
 	.entry-content > &.alignleft {
 		@extend %responsive-alignright-mobile;
 		@extend %responsive-alignright;
-
 		margin-right: var(--global--spacing-horizontal);
+
 		@include media(mobile-only) {
 			margin-left: 0;
 		}

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -117,25 +117,25 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	max-width: var(--responsive--alignfull-width);
 }
 
-.entry-content > .alignleft {
+.entry-content > .wp-block-cover.alignright, .entry-content > .wp-block-cover-image.alignright, .entry-content > .alignleft {
 	margin-left: 0;
 	margin-right: var(--responsive--spacing-horizontal);
 }
 
 @media only screen and (min-width: 482px) {
-	.entry-content .wp-block-button.alignright, .entry-content > .alignleft {
+	.entry-content .wp-block-button.alignright, .entry-content > .wp-block-cover.alignright, .entry-content > .wp-block-cover-image.alignright, .entry-content > .alignleft {
 		margin-left: auto;
 		margin-right: var(--responsive--alignleft-margin);
 	}
 }
 
-.entry-content > .alignright {
+.entry-content > .wp-block-cover.alignleft, .entry-content > .wp-block-cover-image.alignleft, .entry-content > .alignright {
 	margin-left: var(--responsive--spacing-horizontal);
 	margin-right: 0;
 }
 
 @media only screen and (min-width: 482px) {
-	.entry-content .wp-block-button.alignleft, .entry-content > .alignright {
+	.entry-content .wp-block-button.alignleft, .entry-content > .wp-block-cover.alignleft, .entry-content > .wp-block-cover-image.alignleft, .entry-content > .alignright {
 		margin-left: var(--responsive--alignright-margin);
 		margin-right: auto;
 	}
@@ -1410,6 +1410,30 @@ button[data-load-more-btn],
 .wp-block-cover .wp-block-cover__inner-container > *:last-child,
 .wp-block-cover-image .wp-block-cover__inner-container > *:last-child {
 	margin-bottom: 0;
+}
+
+.entry-content > .wp-block-cover.alignright, .entry-content >
+.wp-block-cover-image.alignright {
+	margin-right: var(--global--spacing-horizontal);
+}
+
+@media only screen and (max-width: 481px) {
+	.entry-content > .wp-block-cover.alignright, .entry-content >
+	.wp-block-cover-image.alignright {
+		margin-left: 0;
+	}
+}
+
+.entry-content > .wp-block-cover.alignleft, .entry-content >
+.wp-block-cover-image.alignleft {
+	margin-left: var(--global--spacing-horizontal);
+}
+
+@media only screen and (max-width: 481px) {
+	.entry-content > .wp-block-cover.alignleft, .entry-content >
+	.wp-block-cover-image.alignleft {
+		margin-right: 0;
+	}
 }
 
 .wp-block-cover.alignleft, .wp-block-cover.alignright,

--- a/varya/style.css
+++ b/varya/style.css
@@ -117,7 +117,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	max-width: var(--responsive--alignfull-width);
 }
 
-.entry-content > .alignleft {
+.entry-content > .wp-block-cover.alignright, .entry-content > .wp-block-cover-image.alignright, .entry-content > .alignleft {
 	/*rtl:ignore*/
 	margin-left: 0;
 	/*rtl:ignore*/
@@ -125,7 +125,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 }
 
 @media only screen and (min-width: 482px) {
-	.entry-content .wp-block-button.alignright, .entry-content > .alignleft {
+	.entry-content .wp-block-button.alignright, .entry-content > .wp-block-cover.alignright, .entry-content > .wp-block-cover-image.alignright, .entry-content > .alignleft {
 		/*rtl:ignore*/
 		margin-left: auto;
 		/*rtl:ignore*/
@@ -133,7 +133,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-.entry-content > .alignright {
+.entry-content > .wp-block-cover.alignleft, .entry-content > .wp-block-cover-image.alignleft, .entry-content > .alignright {
 	/*rtl:ignore*/
 	margin-left: var(--responsive--spacing-horizontal);
 	/*rtl:ignore*/
@@ -141,7 +141,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 }
 
 @media only screen and (min-width: 482px) {
-	.entry-content .wp-block-button.alignleft, .entry-content > .alignright {
+	.entry-content .wp-block-button.alignleft, .entry-content > .wp-block-cover.alignleft, .entry-content > .wp-block-cover-image.alignleft, .entry-content > .alignright {
 		/*rtl:ignore*/
 		margin-left: var(--responsive--alignright-margin);
 		/*rtl:ignore*/
@@ -1418,6 +1418,30 @@ button[data-load-more-btn],
 .wp-block-cover .wp-block-cover__inner-container > *:last-child,
 .wp-block-cover-image .wp-block-cover__inner-container > *:last-child {
 	margin-bottom: 0;
+}
+
+.entry-content > .wp-block-cover.alignright, .entry-content >
+.wp-block-cover-image.alignright {
+	margin-left: var(--global--spacing-horizontal);
+}
+
+@media only screen and (max-width: 481px) {
+	.entry-content > .wp-block-cover.alignright, .entry-content >
+	.wp-block-cover-image.alignright {
+		margin-right: 0;
+	}
+}
+
+.entry-content > .wp-block-cover.alignleft, .entry-content >
+.wp-block-cover-image.alignleft {
+	margin-right: var(--global--spacing-horizontal);
+}
+
+@media only screen and (max-width: 481px) {
+	.entry-content > .wp-block-cover.alignleft, .entry-content >
+	.wp-block-cover-image.alignleft {
+		margin-left: 0;
+	}
 }
 
 .wp-block-cover.alignleft, .wp-block-cover.alignright,


### PR DESCRIPTION
Fixes an issue where left/right aligned cover blocks will spill out of the text column.

Before|After
-----------|-----------
![image](https://user-images.githubusercontent.com/709581/78940921-a625fa80-7a84-11ea-8de2-1906cf942acd.png)|![image](https://user-images.githubusercontent.com/709581/78940781-6b23c700-7a84-11ea-93e9-c4b1f23c08e7.png)

 The alignment class for Cover sits directly on the element like this: `.entry-content > .wp-block-cover.alignright/left` element. Other blocks like button or image nest the alignment class like this: `.entry-content > .wp-block-button > .alignright/left`. This means the utility class has to applied differently for each condition. This fix overrides the utility class so the Cover block is treated slightly different but still works as expected as far as the system goes.

- Fixes: #55