### PR TITLE
Varya: Removing light and dark border-color and variables.

### DIFF
--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -1822,7 +1822,7 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__image--placeholder {
-	border-color: var(--global--color-border-light);
+	border-color: var(--global--color-border);
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger {
@@ -1831,11 +1831,11 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger::before {
-	border-color: var(--global--color-border-dark);
+	border-color: var(--global--color-border);
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger::after {
-	background-color: var(--global--color-border-dark);
+	background-color: var(--global--color-border);
 }
 
 .single-product #page #woocommerce-wrapper div.product div.summary {

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -1822,7 +1822,7 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__image--placeholder {
-	border-color: var(--global--color-border-light);
+	border-color: var(--global--color-border);
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger {
@@ -1831,11 +1831,11 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger::before {
-	border-color: var(--global--color-border-dark);
+	border-color: var(--global--color-border);
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger::after {
-	background-color: var(--global--color-border-dark);
+	background-color: var(--global--color-border);
 }
 
 .single-product #page #woocommerce-wrapper div.product div.summary {

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -57,8 +57,6 @@ body {
 	--global--color-background-light: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #757575;
-	--global--color-border-light: #444444;
-	--global--color-border-dark: #DDDDDD;
 	--global--color-text-selection: #FAFBF6;
 	--global--color-alert-success: yellowgreen;
 	--global--color-alert-info: skyblue;

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -57,8 +57,6 @@
 	--global--color-background-light: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #757575;
-	--global--color-border-light: #444444;
-	--global--color-border-dark: #DDDDDD;
 	--global--color-text-selection: #FAFBF6;
 	--global--color-alert-success: yellowgreen;
 	--global--color-alert-info: skyblue;

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -44,8 +44,6 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--color-background-light: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #757575;
-	--global--color-border-light: #444444;
-	--global--color-border-dark: #DDDDDD;
 	--global--color-text-selection: #FAFBF6;
 	--global--color-alert-success: yellowgreen;
 	--global--color-alert-info: skyblue;

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -57,8 +57,6 @@ body {
 	--global--color-background-light: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #757575;
-	--global--color-border-light: #444444;
-	--global--color-border-dark: #DDDDDD;
 	--global--color-text-selection: #FAFBF6;
 	--global--color-alert-success: yellowgreen;
 	--global--color-alert-info: skyblue;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -57,8 +57,6 @@
 	--global--color-background-light: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #757575;
-	--global--color-border-light: #444444;
-	--global--color-border-dark: #DDDDDD;
 	--global--color-text-selection: #FAFBF6;
 	--global--color-alert-success: yellowgreen;
 	--global--color-alert-info: skyblue;

--- a/varya/assets/sass/components/comments/_comments.scss
+++ b/varya/assets/sass/components/comments/_comments.scss
@@ -59,7 +59,7 @@
 	}
 
 	> li:not(first-child) {
-		border-bottom: 1px solid var(--global--color-border-dark);
+		border-bottom: 1px solid var(--global--color-border);
 	}
 }
 
@@ -68,7 +68,7 @@
 	padding-left: var(--global--spacing-horizontal);
 
 	> li {
-		border-top: 1px solid var(--global--color-border-dark);
+		border-top: 1px solid var(--global--color-border);
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
 	}
@@ -195,7 +195,7 @@
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
 	}
-	
+
 	.reply {
 		margin: calc(1.5 * var(--global--spacing-vertical)) 0;
 	}

--- a/varya/assets/sass/vendors/woocommerce/pages/_single-product.scss
+++ b/varya/assets/sass/vendors/woocommerce/pages/_single-product.scss
@@ -17,7 +17,7 @@
 			}
 
 			.woocommerce-product-gallery__image--placeholder {
-				border-color: var(--global--color-border-light);
+				border-color: var(--global--color-border);
 			}
 
 			.woocommerce-product-gallery__trigger {
@@ -25,11 +25,11 @@
 				background: var(--global--color-background);
 
 				&::before {
-					border-color: var(--global--color-border-dark);
+					border-color: var(--global--color-border);
 				}
 
 				&::after {
-					background-color: var(--global--color-border-dark);
+					background-color: var(--global--color-border);
 				}
 			}
 		}

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3343,7 +3343,7 @@ nav a {
 }
 
 .comment-list > li:not(first-child) {
-	border-bottom: 1px solid var(--global--color-border-dark);
+	border-bottom: 1px solid var(--global--color-border);
 }
 
 .comment-list .children {
@@ -3352,7 +3352,7 @@ nav a {
 }
 
 .comment-list .children > li {
-	border-top: 1px solid var(--global--color-border-dark);
+	border-top: 1px solid var(--global--color-border);
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
 }

--- a/varya/style.css
+++ b/varya/style.css
@@ -3368,7 +3368,7 @@ nav a {
 }
 
 .comment-list > li:not(first-child) {
-	border-bottom: 1px solid var(--global--color-border-dark);
+	border-bottom: 1px solid var(--global--color-border);
 }
 
 .comment-list .children {
@@ -3377,7 +3377,7 @@ nav a {
 }
 
 .comment-list .children > li {
-	border-top: 1px solid var(--global--color-border-dark);
+	border-top: 1px solid var(--global--color-border);
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
 }


### PR DESCRIPTION
This PR removes the `--global--color-border-light` and `--global--color-border-dark` variables from the system and replaces each with the singular `--global--color-border` color variable. 

There were only a few instances of these colors in the theme already. 
- The comment-list border color
- A couple of minor instances of border colors on images in WooCommerce.

Fixes: #57 