### PR TITLE
Varya: Clean up desktop menu alignment

### DIFF
--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -748,6 +748,9 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 }
 
 @media only screen and (min-width: 482px) {
+	body[class*="woocommerce"] #page .main-navigation {
+		flex-direction: column;
+	}
 	body[class*="woocommerce"] #page .main-navigation #toggle-cart {
 		display: none;
 	}

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -748,9 +748,6 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 }
 
 @media only screen and (min-width: 482px) {
-	body[class*="woocommerce"] #page .main-navigation > div:not(:last-of-type) {
-		margin-left: calc(2 * var(--global--spacing-unit));
-	}
 	body[class*="woocommerce"] #page .main-navigation #toggle-cart {
 		display: none;
 	}

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -748,8 +748,8 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 }
 
 @media only screen and (min-width: 482px) {
-	body[class*="woocommerce"] #page .main-navigation > div:not(:last-of-type) {
-		margin-right: calc(2 * var(--global--spacing-unit));
+	body[class*="woocommerce"] #page .main-navigation {
+		flex-direction: column;
 	}
 	body[class*="woocommerce"] #page .main-navigation #toggle-cart {
 		display: none;

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -128,6 +128,7 @@
 	// Menu list wrapper
 	& > div > ul {
 		display: flex;
+		justify-content: var(--primary-nav--justify-content);
 		flex-wrap: wrap;
 		list-style: none;
 		margin: 0;
@@ -172,14 +173,6 @@
 			@include media(mobile) {
 				& > a {
 					@include crop-text(var(--global--line-height-base));
-				}
-
-				&:first-of-type > a {
-					padding-left: 0;
-				}
-
-				&:last-of-type > a {
-					padding-right: 0;
 				}
 			}
 		}

--- a/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
+++ b/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
@@ -90,10 +90,7 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 		}
 
 		@include media(mobile) {
-
-			& > div:not(:last-of-type) {
-				margin-right: calc(2 * var(--global--spacing-unit));
-			}
+			flex-direction: column;
 
 			#toggle-cart {
 				display: none;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2729,6 +2729,7 @@ nav a {
 
 .main-navigation > div > ul {
 	display: flex;
+	justify-content: var(--primary-nav--justify-content);
 	flex-wrap: wrap;
 	list-style: none;
 	margin: 0;
@@ -2785,12 +2786,6 @@ nav a {
 	}
 	.main-navigation > div > ul > li > a:after {
 		margin-top: -calc(.5em * var(--button--line-height) + -.39);
-	}
-	.main-navigation > div > ul > li:first-of-type > a {
-		padding-right: 0;
-	}
-	.main-navigation > div > ul > li:last-of-type > a {
-		padding-left: 0;
 	}
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -2754,6 +2754,7 @@ nav a {
 
 .main-navigation > div > ul {
 	display: flex;
+	justify-content: var(--primary-nav--justify-content);
 	flex-wrap: wrap;
 	list-style: none;
 	margin: 0;
@@ -2810,12 +2811,6 @@ nav a {
 	}
 	.main-navigation > div > ul > li > a:after {
 		margin-top: -calc(.5em * var(--button--line-height) + -.39);
-	}
-	.main-navigation > div > ul > li:first-of-type > a {
-		padding-left: 0;
-	}
-	.main-navigation > div > ul > li:last-of-type > a {
-		padding-right: 0;
 	}
 }
 


### PR DESCRIPTION
This PR properly centers menu items when they wrap. It also modifies the WooCommerce cart position so that it sits below the main navigation. This looks less awkward in general. 

Before:

![before](https://user-images.githubusercontent.com/1202812/78945392-30bf2780-7a8e-11ea-81de-b2d30207d73b.png)

![dotorgthemes test_ (2)](https://user-images.githubusercontent.com/1202812/78945404-37e63580-7a8e-11ea-8713-ec9ecd090df8.png)

After:

![after](https://user-images.githubusercontent.com/1202812/78945413-3c125300-7a8e-11ea-8835-c90f274dd636.png)

![dotorgthemes test_ (1)](https://user-images.githubusercontent.com/1202812/78945417-3e74ad00-7a8e-11ea-8cd5-5f6858842edb.png)
