### PR TITLE
Varya: Rename "menu-1" to "primary"

### DIFF
--- a/varya/functions.php
+++ b/varya/functions.php
@@ -56,7 +56,7 @@ if ( ! function_exists( 'varya_setup' ) ) :
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(
 			array(
-				'menu-1' => __( 'Primary Navigation', 'varya' ),
+				'primary' => __( 'Primary Navigation', 'varya' ),
 				'footer' => __( 'Footer Navigation', 'varya' ),
 				'social' => __( 'Social Links Navigation', 'varya' ),
 			)
@@ -295,7 +295,7 @@ function varya_scripts() {
 	$menu = wp_nav_menu(
 		array (
 			'echo' => FALSE,
-			'menu' => 'menu-1',
+			'menu' => 'primary',
 			'fallback_cb' => '__return_false'
 		)
 	);

--- a/varya/header.php
+++ b/varya/header.php
@@ -27,7 +27,7 @@
 
 			<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 
-			<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
+			<?php if ( has_nav_menu( 'primary' ) ) : ?>
 				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main Navigation', 'varya' ); ?>">
 					<button id="toggle-menu" class="button">
 						<span class="dropdown-icon open"><?php _e( 'Menu', 'varya' ); ?> <?php echo varya_get_icon_svg( 'menu_open' ) ?></span>
@@ -37,14 +37,14 @@
 					</button>
 					<?php
 					// Get menu slug
-					$location_name = 'menu-1';
+					$location_name = 'primary';
 					$locations = get_nav_menu_locations();
 					$menu_id = $locations[ $location_name ];
 					$menu = wp_get_nav_menu_object( $menu_id );
 
 					wp_nav_menu(
 						array(
-							'theme_location'  => 'menu-1',
+							'theme_location'  => 'primary',
 							'menu_class'      => 'main-menu',
 							'container_class' => 'main-menu-container menu-'. $menu->slug .'-container',
 							'items_wrap'      => '<ul id="%1$s" class="%2$s" aria-label="submenu">%3$s</ul>',

--- a/varya/inc/template-functions.php
+++ b/varya/inc/template-functions.php
@@ -206,11 +206,11 @@ add_filter( 'the_content_more_link', 'varya_continue_reading_link' );
 function varya_add_dropdown_icons( $output, $item, $depth, $args ) {
 
 	// Only add class to 'top level' items on the 'primary' menu.
-	if ( ! isset( $args->theme_location ) || 'menu-1' !== $args->theme_location ) {
+	if ( ! isset( $args->theme_location ) || 'primary' !== $args->theme_location ) {
 		return $output;
 	}
 
-	if ( 'menu-1' == $args->theme_location && $depth === 0 ) {
+	if ( 'primary' == $args->theme_location && $depth === 0 ) {
 		if ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
 
 			// Add SVG icon to parent items.
@@ -233,7 +233,7 @@ add_filter( 'walker_nav_menu_start_el', 'varya_add_dropdown_icons', 10, 4 );
  */
 function varya_add_mobile_parent_nav_menu_items( $sorted_menu_items, $args ) {
 	static $pseudo_id = 0;
-	if ( ! isset( $args->theme_location ) || 'menu-1' !== $args->theme_location ) {
+	if ( ! isset( $args->theme_location ) || 'primary' !== $args->theme_location ) {
 		return $sorted_menu_items;
 	}
 

--- a/varya/inc/woocommerce.php
+++ b/varya/inc/woocommerce.php
@@ -212,7 +212,7 @@ if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.3', '>=' ) ) {
  * Add WooCommerce mini-cart link to primary menu
  */
 function varya_add_cart_menu( $nav, $args ) {
-	if ( $args->theme_location == 'menu-1' ) {
+	if ( $args->theme_location == 'primary' ) {
 		return sprintf(
 			'%1$s
 			</ul></div>


### PR DESCRIPTION
Fixes #60 

Renames the `menu-1` menu location to `primary` so it's a bit more clear. 

(Heads up, after switching to this PR, you'll have to re-assign a menu to this new location)