### PR TITLE
Varya: Adjust the appearance of the sticky flag

### DIFF
--- a/varya/assets/sass/pages/_posts-and-pages.scss
+++ b/varya/assets/sass/pages/_posts-and-pages.scss
@@ -4,12 +4,11 @@
 
 .sticky-post {
 	color: var(--global--color-background);
-	background-color: var(--global--color-primary);
-	font-family: var(--global--font-primary);
-	font-weight: bold;
-	font-size: var(--global--font-size-sm);
+	background-color: var(--global--color-secondary);
+	font-family: var(--global--font-secondary);
+	font-size: var(--global--font-size-xs);
 	line-height: 1;
-	padding: calc(0.5 * var(--global--spacing-unit)) calc(0.66 * var(--global--spacing-unit));
+	padding: calc(0.25 * var(--global--spacing-unit)) calc(0.33 * var(--global--spacing-unit));
 }
 
 .updated:not(.published) {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3610,12 +3610,11 @@ img#wpstats {
  */
 .sticky-post {
 	color: var(--global--color-background);
-	background-color: var(--global--color-primary);
-	font-family: var(--global--font-primary);
-	font-weight: bold;
-	font-size: var(--global--font-size-sm);
+	background-color: var(--global--color-secondary);
+	font-family: var(--global--font-secondary);
+	font-size: var(--global--font-size-xs);
 	line-height: 1;
-	padding: calc(0.5 * var(--global--spacing-unit)) calc(0.66 * var(--global--spacing-unit));
+	padding: calc(0.25 * var(--global--spacing-unit)) calc(0.33 * var(--global--spacing-unit));
 }
 
 .page-title {

--- a/varya/style.css
+++ b/varya/style.css
@@ -3635,12 +3635,11 @@ img#wpstats {
  */
 .sticky-post {
 	color: var(--global--color-background);
-	background-color: var(--global--color-primary);
-	font-family: var(--global--font-primary);
-	font-weight: bold;
-	font-size: var(--global--font-size-sm);
+	background-color: var(--global--color-secondary);
+	font-family: var(--global--font-secondary);
+	font-size: var(--global--font-size-xs);
 	line-height: 1;
-	padding: calc(0.5 * var(--global--spacing-unit)) calc(0.66 * var(--global--spacing-unit));
+	padding: calc(0.25 * var(--global--spacing-unit)) calc(0.33 * var(--global--spacing-unit));
 }
 
 .page-title {


### PR DESCRIPTION
Fixes #54 

Uses the secondary color (red), and reduces the font and padding size so it's less prominent. Also uses the secondary font, since the  primary one is generally reserved for headings.

Before: 

![dotorgthemes test_ (8)](https://user-images.githubusercontent.com/1202812/78994311-b8984680-7b0d-11ea-95c1-12313147d8da.png)

After:

![dotorgthemes test_ (9)](https://user-images.githubusercontent.com/1202812/78994324-c2ba4500-7b0d-11ea-87d1-10a849dabd49.png)
