### PR TITLE
Varya: Woo and primary menu overlap on hover  

### DIFF
--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -31,6 +31,10 @@
  	  	transform: translateY(var(--global--spacing-vertical));
 	}
 
+	.woocommerce-menu-container {
+		z-index: 498;
+	}
+
 	// Mobile menu toggle
 	#toggle-menu {
 		position: absolute;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2657,7 +2657,8 @@ nav a {
 	}
 }
 
-.main-navigation > div {
+.main-navigation .main-menu-container,
+.main-navigation .woocommerce-menu-container {
 	visibility: hidden;
 	opacity: 0;
 	position: fixed;
@@ -2669,9 +2670,16 @@ nav a {
 	background-color: var(--global--color-background);
 	overflow-x: hidden;
 	overflow-y: scroll;
-	z-index: 499;
 	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
+}
+
+.main-navigation .main-menu-container {
+	z-index: 499;
+}
+
+.main-navigation .woocommerce-menu-container {
+	z-index: 498;
 }
 
 .main-navigation #toggle-menu {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2657,8 +2657,7 @@ nav a {
 	}
 }
 
-.main-navigation .main-menu-container,
-.main-navigation .woocommerce-menu-container {
+.main-navigation > div {
 	visibility: hidden;
 	opacity: 0;
 	position: fixed;
@@ -2670,12 +2669,9 @@ nav a {
 	background-color: var(--global--color-background);
 	overflow-x: hidden;
 	overflow-y: scroll;
+	z-index: 499;
 	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
-}
-
-.main-navigation .main-menu-container {
-	z-index: 499;
 }
 
 .main-navigation .woocommerce-menu-container {

--- a/varya/style.css
+++ b/varya/style.css
@@ -2699,6 +2699,10 @@ nav a {
 	transform: translateY(var(--global--spacing-vertical));
 }
 
+.main-navigation .woocommerce-menu-container {
+	z-index: 498;
+}
+
 .main-navigation #toggle-menu {
 	position: absolute;
 	display: inline-block;


### PR DESCRIPTION
When hovering on the main menu that has sub-menu, the sub-menu conflicts with the WooCommerce menu stacking order. This PR lowers the stacking order of the Woo menu.

**Before**
![Kapture 2020-04-10 at 13 13 33](https://user-images.githubusercontent.com/5375500/79016006-f14f1480-7b3b-11ea-82b2-be1df4eabd93.gif)

**After**
<img width="813" alt="Screen Shot 2020-04-10 at 3 00 31 PM" src="https://user-images.githubusercontent.com/5375500/79016057-0cba1f80-7b3c-11ea-99ec-5b6b118efdcd.png">