### PR TITLE
Varya: Alternative approach to correcting menu animation jump

### DIFF
--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -754,6 +754,9 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .woocom
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .woocommerce-cart-count {
 	color: var(--wc--mini-cart--color-count);
 	font-weight: normal;
+	white-space: nowrap;
+	display: inline-block;
+	vertical-align: bottom;
 }
 
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-icon {
@@ -765,7 +768,8 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 
 @media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link {
-		display: inline-block;
+		display: flex;
+		flex-wrap: nowrap;
 	}
 }
 

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -683,20 +683,12 @@ body[class*="woocommerce"] #page .wc-block-grid__product-add-to-cart .added_to_c
 	text-decoration: none;
 }
 
-body[class*="woocommerce"] #page .main-navigation #toggle-cart {
-	position: absolute;
-	display: inline-block;
+body[class*="woocommerce"] #page .main-navigation > #toggle-cart {
 	right: 0;
-	margin: 0;
-	background-color: transparent;
-	color: var(--primary-nav--color-link);
+	top: 0;
 }
 
-body[class*="woocommerce"] #page .main-navigation #toggle-cart:hover {
-	color: var(--primary-nav--color-hover);
-}
-
-body[class*="woocommerce"] #page .main-navigation #toggle-cart .svg-icon {
+body[class*="woocommerce"] #page .main-navigation > #toggle-cart .svg-icon {
 	vertical-align: middle;
 }
 
@@ -722,17 +714,8 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 }
 
 @media only screen and (max-width: 481px) {
-	body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation #toggle-cart {
+	body[class*="woocommerce"].admin-bar.lock-scrolling #page .main-navigation #toggle-cart {
 		top: 46px;
-	}
-	body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation #toggle-menu {
-		top: -46px;
-	}
-	body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation #toggle-menu {
-		top: 46px;
-	}
-	body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation #toggle-cart {
-		top: -46px;
 	}
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -686,6 +686,7 @@ body[class*="woocommerce"] #page .wc-block-grid__product-add-to-cart .added_to_c
 body[class*="woocommerce"] #page .main-navigation > #toggle-cart {
 	right: 0;
 	top: 0;
+	left: auto;
 }
 
 body[class*="woocommerce"] #page .main-navigation > #toggle-cart .svg-icon {

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -729,9 +729,12 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 }
 
 @media only screen and (min-width: 482px) {
+<<<<<<< HEAD
 	body[class*="woocommerce"] #page .main-navigation {
 		flex-direction: column;
 	}
+=======
+>>>>>>> Varya: Force mini-cart text to sit on one line at all times.
 	body[class*="woocommerce"] #page .main-navigation #toggle-cart {
 		display: none;
 	}
@@ -768,6 +771,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 
 @media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link {
+		align-items: center;
 		display: flex;
 		flex-wrap: nowrap;
 	}

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -699,9 +699,6 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation > .woocomme
 }
 
 body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-cart {
-	position: fixed;
-	top: 0;
-	right: 0;
 	z-index: 500;
 }
 
@@ -720,8 +717,6 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);
 		color: var(--wc--mini-cart--color-text);
-		padding: calc(4* var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
-		width: 100%;
 	}
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container a,
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container a:link,

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -722,14 +722,17 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 }
 
 @media only screen and (max-width: 481px) {
-	body[class*="woocommerce"].admin-bar #page .main-navigation {
-		top: 46px;
-	}
-	body[class*="woocommerce"].admin-bar #page .main-navigation > .woocommerce-menu-container {
-		top: 46px;
-	}
 	body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation #toggle-cart {
 		top: 46px;
+	}
+	body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation #toggle-menu {
+		top: -46px;
+	}
+	body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation #toggle-menu {
+		top: 46px;
+	}
+	body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation #toggle-cart {
+		top: -46px;
 	}
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -700,6 +700,8 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation > .woocomme
 }
 
 body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-cart {
+	right: auto;
+	left: 0;
 	z-index: 500;
 }
 

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -700,6 +700,8 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation > .woocomme
 }
 
 body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-cart {
+	left: auto;
+	right: 0;
 	z-index: 500;
 }
 

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -686,6 +686,7 @@ body[class*="woocommerce"] #page .wc-block-grid__product-add-to-cart .added_to_c
 body[class*="woocommerce"] #page .main-navigation > #toggle-cart {
 	left: 0;
 	top: 0;
+	right: auto;
 }
 
 body[class*="woocommerce"] #page .main-navigation > #toggle-cart .svg-icon {

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -683,20 +683,12 @@ body[class*="woocommerce"] #page .wc-block-grid__product-add-to-cart .added_to_c
 	text-decoration: none;
 }
 
-body[class*="woocommerce"] #page .main-navigation #toggle-cart {
-	position: absolute;
-	display: inline-block;
+body[class*="woocommerce"] #page .main-navigation > #toggle-cart {
 	left: 0;
-	margin: 0;
-	background-color: transparent;
-	color: var(--primary-nav--color-link);
+	top: 0;
 }
 
-body[class*="woocommerce"] #page .main-navigation #toggle-cart:hover {
-	color: var(--primary-nav--color-hover);
-}
-
-body[class*="woocommerce"] #page .main-navigation #toggle-cart .svg-icon {
+body[class*="woocommerce"] #page .main-navigation > #toggle-cart .svg-icon {
 	vertical-align: middle;
 }
 
@@ -707,9 +699,6 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation > .woocomme
 }
 
 body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-cart {
-	position: fixed;
-	top: 0;
-	left: 0;
 	z-index: 500;
 }
 
@@ -722,17 +711,8 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 }
 
 @media only screen and (max-width: 481px) {
-	body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation #toggle-cart {
+	body[class*="woocommerce"].admin-bar.lock-scrolling #page .main-navigation #toggle-cart {
 		top: 46px;
-	}
-	body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation #toggle-menu {
-		top: -46px;
-	}
-	body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation #toggle-menu {
-		top: 46px;
-	}
-	body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation #toggle-cart {
-		top: -46px;
 	}
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -717,8 +717,6 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);
 		color: var(--wc--mini-cart--color-text);
-		padding: calc(4* var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
-		width: 100%;
 	}
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container a,
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container a:link,

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -722,14 +722,17 @@ body[class*="woocommerce"].wc-navigation-open #page .main-navigation #toggle-car
 }
 
 @media only screen and (max-width: 481px) {
-	body[class*="woocommerce"].admin-bar #page .main-navigation {
-		top: 46px;
-	}
-	body[class*="woocommerce"].admin-bar #page .main-navigation > .woocommerce-menu-container {
-		top: 46px;
-	}
 	body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation #toggle-cart {
 		top: 46px;
+	}
+	body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation #toggle-menu {
+		top: -46px;
+	}
+	body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation #toggle-menu {
+		top: 46px;
+	}
+	body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation #toggle-cart {
+		top: -46px;
 	}
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
 		background-color: var(--wc--mini-cart--color-background);

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -754,6 +754,9 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .woocom
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .woocommerce-cart-count {
 	color: var(--wc--mini-cart--color-count);
 	font-weight: normal;
+	white-space: nowrap;
+	display: inline-block;
+	vertical-align: bottom;
 }
 
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-icon {
@@ -765,7 +768,9 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 
 @media only screen and (min-width: 482px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link {
-		display: inline-block;
+		align-items: center;
+		display: flex;
+		flex-wrap: nowrap;
 	}
 }
 

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -31,12 +31,13 @@
  	  	transform: translateY(var(--global--spacing-vertical));
 	}
 
-	// Mobile menu toggle
-	#toggle-menu {
+	// Mobile menu toggles
+	> .button {
 		position: absolute;
 		display: inline-block;
 		margin: 0;
 		right: 0;
+		top: 0;
 		background-color: transparent;
 		color: var(--primary-nav--color-link);
 
@@ -54,10 +55,8 @@
 			transform: translateY(0);
 		}
 
-		#toggle-menu {
-			position: fixed;
-			top: 0;
-			right: 0;
+		> #toggle-menu {
+
 			z-index: 500;
 
 			.open {
@@ -74,18 +73,20 @@
 		display: none;
 	}
 
-	// Adjust position when logged-in
-	.admin-bar & {
-		top: 46px;
-
-		& > div {
-			top: 46px;
+	// Adjust button postion when scrolling is locked
+	.lock-scrolling & {
+		> .button {
+			position: fixed;
+			top: 0;
+			right: 0;
 		}
 	}
-	.admin-bar.main-navigation-open & {
-		#toggle-menu {
-			top: 46px;
-		}
+
+	// Adjust positions when logged-in
+	.admin-bar &,
+	.admin-bar & > div,
+	.admin-bar.lock-scrolling & > .button {
+		top: 46px;
 	}
 
 	@include media(mobile) {

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -18,17 +18,20 @@
 		visibility: hidden;
 		opacity: 0;
 		position: fixed;
- 		top: 0;
- 		right: 0;
- 		bottom: 0;
- 		left: 0;
- 		padding: calc(4* var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
- 		background-color: var(--global--color-background);
- 		overflow-x: hidden;
- 		overflow-y: scroll;
- 		z-index: 499;
- 		transition: all .15s ease-in-out;
- 	  	transform: translateY(var(--global--spacing-vertical));
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		padding: calc(4* var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
+		background-color: var(--global--color-background);
+		overflow-x: hidden;
+		overflow-y: scroll;
+		transition: all .15s ease-in-out;
+		transform: translateY(var(--global--spacing-vertical));
+
+		@include media(mobile-only) {
+			z-index: 499;
+		}
 	}
 
 	// Mobile menu toggles

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -27,7 +27,7 @@
  		overflow-x: hidden;
  		overflow-y: scroll;
  		z-index: 499;
- 		transition: all 2s ease-in-out;
+ 		transition: all .15s ease-in-out;
  	  	transform: translateY(var(--global--spacing-vertical));
 	}
 

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -27,7 +27,7 @@
  		overflow-x: hidden;
  		overflow-y: scroll;
  		z-index: 499;
- 		transition: all .15s ease-in-out;
+ 		transition: all 2s ease-in-out;
  	  	transform: translateY(var(--global--spacing-vertical));
 	}
 

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -74,12 +74,10 @@
 	}
 
 	// Adjust button postion when scrolling is locked
-	.lock-scrolling & {
-		> .button {
-			position: fixed;
-			top: 0;
-			right: 0;
-		}
+	.lock-scrolling & > .button {
+		position: fixed;
+		top: 0;
+		right: 0;
 	}
 
 	// Adjust positions when logged-in

--- a/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
+++ b/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
@@ -33,6 +33,8 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 
 			#toggle-cart {
 
+				left: auto;
+				right: 0;
 				z-index: 500;
 
 				.open {

--- a/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
+++ b/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
@@ -55,8 +55,6 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 
 				background-color: var(--wc--mini-cart--color-background);
 				color: var(--wc--mini-cart--color-text);
-				padding: calc(4* var(--global--spacing-unit)) var(--global--spacing-unit) var(--global--spacing-horizontal);
-				width: 100%;
 
 				a,
 				a:link,

--- a/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
+++ b/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
@@ -93,6 +93,9 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 			.woocommerce-cart-count {
 				color: var(--wc--mini-cart--color-count);
 				font-weight: normal;
+				white-space: nowrap;
+				display: inline-block;
+				vertical-align: bottom;
 			}
 
 			.svg-icon {
@@ -103,7 +106,9 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 			}
 
 			@include media(mobile) {
-				display: inline-block;
+				align-items: center;
+				display: flex;
+				flex-wrap: nowrap;
 			}
 		}
 

--- a/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
+++ b/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
@@ -15,6 +15,7 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 		> #toggle-cart {
 			left: 0;
 			top: 0;
+			right: auto;
 
 			.svg-icon {
 				vertical-align: middle;

--- a/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
+++ b/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
@@ -57,16 +57,22 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 		@include media(mobile-only) {
 
 			// Adjust position when logged-in
-			@at-root body[class*="woocommerce"].admin-bar #page .main-navigation {
-				top: 46px;
-
-				& > .woocommerce-menu-container {
-					top: 46px;
-				}
-			}
 			@at-root body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation {
 				#toggle-cart {
 					top: 46px;
+				}
+
+				#toggle-menu {
+					top: -46px;
+				}
+			}
+			@at-root body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation {
+				#toggle-menu {
+					top: 46px;
+				}
+			
+				#toggle-cart {
+					top: -46px;
 				}
 			}
 

--- a/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
+++ b/varya/assets/sass/vendors/woocommerce/components/_mini-cart.scss
@@ -12,17 +12,9 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 	.main-navigation {
 
 		// Mobile menu toggle
-		#toggle-cart {
-			position: absolute;
-			display: inline-block;
+		> #toggle-cart {
 			left: 0;
-			margin: 0;
-			background-color: transparent;
-			color: var(--primary-nav--color-link);
-
-			&:hover {
-				color: var(--primary-nav--color-hover);
-			}
+			top: 0;
 
 			.svg-icon {
 				vertical-align: middle;
@@ -39,9 +31,7 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 			}
 
 			#toggle-cart {
-				position: fixed;
-				top: 0;
-				left: 0;
+
 				z-index: 500;
 
 				.open {
@@ -57,23 +47,8 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 		@include media(mobile-only) {
 
 			// Adjust position when logged-in
-			@at-root body[class*="woocommerce"].admin-bar.wc-navigation-open #page .main-navigation {
-				#toggle-cart {
-					top: 46px;
-				}
-
-				#toggle-menu {
-					top: -46px;
-				}
-			}
-			@at-root body[class*="woocommerce"].admin-bar.main-navigation-open #page .main-navigation {
-				#toggle-menu {
-					top: 46px;
-				}
-			
-				#toggle-cart {
-					top: -46px;
-				}
+			@at-root body[class*="woocommerce"].admin-bar.lock-scrolling #page .main-navigation #toggle-cart {
+				top: 46px;
 			}
 
 			.woocommerce-menu-container {

--- a/varya/inc/woocommerce.php
+++ b/varya/inc/woocommerce.php
@@ -6,6 +6,7 @@
  *
  * @package Varya
  */
+
 /**
  * WooCommerce setup function.
  *
@@ -26,6 +27,7 @@ function varya_woocommerce_setup() {
 			'min_rows'        => 1
 		)
 	) ) );
+
 	add_theme_support( 'wc-product-gallery-zoom' );
 	add_theme_support( 'wc-product-gallery-lightbox' );
 	add_theme_support( 'wc-product-gallery-slider' );

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2670,7 +2670,7 @@ nav a {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	z-index: 499;
-	transition: all 3s ease-in-out;
+	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
 }
 

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2669,9 +2669,14 @@ nav a {
 	background-color: var(--global--color-background);
 	overflow-x: hidden;
 	overflow-y: scroll;
-	z-index: 499;
 	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
+}
+
+@media only screen and (max-width: 481px) {
+	.main-navigation > div {
+		z-index: 499;
+	}
 }
 
 .main-navigation > .button {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2674,16 +2674,17 @@ nav a {
 	transform: translateY(var(--global--spacing-vertical));
 }
 
-.main-navigation #toggle-menu {
+.main-navigation > .button {
 	position: absolute;
 	display: inline-block;
 	margin: 0;
 	left: 0;
+	top: 0;
 	background-color: transparent;
 	color: var(--primary-nav--color-link);
 }
 
-.main-navigation #toggle-menu:hover {
+.main-navigation > .button:hover {
 	color: var(--primary-nav--color-hover);
 }
 
@@ -2693,18 +2694,15 @@ nav a {
 	transform: translateY(0);
 }
 
-.main-navigation-open .main-navigation #toggle-menu {
-	position: fixed;
-	top: 0;
-	left: 0;
+.main-navigation-open .main-navigation > #toggle-menu {
 	z-index: 500;
 }
 
-.main-navigation-open .main-navigation #toggle-menu .open {
+.main-navigation-open .main-navigation > #toggle-menu .open {
 	display: none;
 }
 
-.main-navigation-open .main-navigation #toggle-menu .close {
+.main-navigation-open .main-navigation > #toggle-menu .close {
 	display: inline;
 }
 
@@ -2712,15 +2710,15 @@ nav a {
 	display: none;
 }
 
-.admin-bar .main-navigation {
-	top: 46px;
+.lock-scrolling .main-navigation > .button {
+	position: fixed;
+	top: 0;
+	left: 0;
 }
 
-.admin-bar .main-navigation > div {
-	top: 46px;
-}
-
-.admin-bar.main-navigation-open .main-navigation #toggle-menu {
+.admin-bar .main-navigation,
+.admin-bar .main-navigation > div,
+.admin-bar.lock-scrolling .main-navigation > .button {
 	top: 46px;
 }
 

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2670,7 +2670,7 @@ nav a {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	z-index: 499;
-	transition: all .15s ease-in-out;
+	transition: all 3s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -2699,16 +2699,17 @@ nav a {
 	transform: translateY(var(--global--spacing-vertical));
 }
 
-.main-navigation #toggle-menu {
+.main-navigation > .button {
 	position: absolute;
 	display: inline-block;
 	margin: 0;
 	right: 0;
+	top: 0;
 	background-color: transparent;
 	color: var(--primary-nav--color-link);
 }
 
-.main-navigation #toggle-menu:hover {
+.main-navigation > .button:hover {
 	color: var(--primary-nav--color-hover);
 }
 
@@ -2718,18 +2719,15 @@ nav a {
 	transform: translateY(0);
 }
 
-.main-navigation-open .main-navigation #toggle-menu {
-	position: fixed;
-	top: 0;
-	right: 0;
+.main-navigation-open .main-navigation > #toggle-menu {
 	z-index: 500;
 }
 
-.main-navigation-open .main-navigation #toggle-menu .open {
+.main-navigation-open .main-navigation > #toggle-menu .open {
 	display: none;
 }
 
-.main-navigation-open .main-navigation #toggle-menu .close {
+.main-navigation-open .main-navigation > #toggle-menu .close {
 	display: inline;
 }
 
@@ -2737,15 +2735,15 @@ nav a {
 	display: none;
 }
 
-.admin-bar .main-navigation {
-	top: 46px;
+.lock-scrolling .main-navigation > .button {
+	position: fixed;
+	top: 0;
+	right: 0;
 }
 
-.admin-bar .main-navigation > div {
-	top: 46px;
-}
-
-.admin-bar.main-navigation-open .main-navigation #toggle-menu {
+.admin-bar .main-navigation,
+.admin-bar .main-navigation > div,
+.admin-bar.lock-scrolling .main-navigation > .button {
 	top: 46px;
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -2695,7 +2695,7 @@ nav a {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	z-index: 499;
-	transition: all 2s ease-in-out;
+	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -2695,7 +2695,7 @@ nav a {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	z-index: 499;
-	transition: all .15s ease-in-out;
+	transition: all 2s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -2694,9 +2694,14 @@ nav a {
 	background-color: var(--global--color-background);
 	overflow-x: hidden;
 	overflow-y: scroll;
-	z-index: 499;
 	transition: all .15s ease-in-out;
 	transform: translateY(var(--global--spacing-vertical));
+}
+
+@media only screen and (max-width: 481px) {
+	.main-navigation > div {
+		z-index: 499;
+	}
 }
 
 .main-navigation > .button {


### PR DESCRIPTION
This is a slightly different approach to the solution in #63.

- It simplifies the Sass structure so both mobile buttons respond to the `.lock-scrolling` class the same exact way. This means all of menu logic can be in `_primary-navigation.scss` and then the `_mini-cart.scss` only has to have overrides for button positioning and minor design related styles.
- Cleans up the z-index rules so both menus can never be visible at the same time.
- Doesn’t cause the unrelated issue [mentioned here](https://github.com/Automattic/themes-workspace/pull/63#pullrequestreview-391557866) to happen.
- Simplifies some of the common nested Sass selectors in a few places.

Before|After
------------|------------
![2020-04-10 15 02 09](https://user-images.githubusercontent.com/1202812/78948763-674d7000-7a97-11ea-932f-88e7bd4c148f.gif)|![2020-04-10 15 02 09](https://user-images.githubusercontent.com/709581/79016172-4db23400-7b3c-11ea-8cf2-a1665e0a3750.gif)
