### PR TITLE
Varya: declare HTML5 scripts and styles support for better compliance with W3C validator

### DIFF
--- a/varya/functions.php
+++ b/varya/functions.php
@@ -74,6 +74,8 @@ if ( ! function_exists( 'varya_setup' ) ) :
 				'comment-list',
 				'gallery',
 				'caption',
+				'style',
+				'script',
 			)
 		);
 


### PR DESCRIPTION
Hi,

Given this theme is written in HTML5, it should declare HTML5 support for styles and script to avoid using `type` attributes in styles and scripts.

Otherwise, W3C validator will throw a warning because of the `type` element.

This option was introduced in WordPress 5.3. For reference, see:
- https://make.wordpress.org/core/2019/10/15/miscellaneous-developer-focused-changes-in-5-3/
- https://core.trac.wordpress.org/ticket/42804#comment:32
