### PR TITLE
Varya: Fix button styles

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -421,7 +421,7 @@ object {
 	color: currentColor;
 }
 
-.wp-block-button .wp-block-button__link {
+.wp-block-button__link {
 	color: var(--button--color-text);
 	font-weight: var(--button--font-weight);
 	font-family: var(--button--font-family);
@@ -432,22 +432,22 @@ object {
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
-.wp-block-button .wp-block-button__link:hover, .wp-block-button .wp-block-button__link:focus, .wp-block-button .wp-block-button__link.has-focus {
+.wp-block-button__link:hover, .wp-block-button__link:focus, .wp-block-button__link.has-focus {
 	color: var(--button--color-text-hover);
 	background-color: var(--button--color-background-hover);
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link {
+.wp-block-button__link.is-style-outline {
 	color: var(--button--color-background);
 	background: transparent;
 	border: 2px solid currentcolor;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link:hover, .wp-block-button.is-style-outline .wp-block-button__link:focus, .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+.wp-block-button__link.is-style-outline:hover, .wp-block-button__link.is-style-outline:focus, .wp-block-button__link.is-style-outline.has-focus {
 	color: var(--button--color-background-hover);
 }
 
-.wp-block-button.is-style-squared .wp-block-button__link {
+.wp-block-button__link.is-style-squared {
 	border-radius: 0;
 }
 

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -437,17 +437,15 @@ object {
 	background-color: var(--button--color-background-hover);
 }
 
-.wp-block-button__link.is-style-outline {
+.wp-block-button__link.is-style-outline,
+.is-style-outline .wp-block-button__link {
 	color: var(--button--color-background);
 	background: transparent;
 	border: 2px solid currentcolor;
 }
 
-.wp-block-button__link.is-style-outline:hover, .wp-block-button__link.is-style-outline:focus, .wp-block-button__link.is-style-outline.has-focus {
-	color: var(--button--color-background-hover);
-}
-
-.wp-block-button__link.is-style-squared {
+.wp-block-button__link.is-style-squared,
+.is-style-squared .wp-block-button__link {
 	border-radius: 0;
 }
 

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -102,7 +102,7 @@ body {
 	--button--font-size: var(--global--font-size-base);
 	--button--font-weight: normal;
 	--button--line-height: 1;
-	--button--border-width: 1px;
+	--button--border-width: 2px;
 	--button--border-radius: 4px;
 	--button--padding-vertical: calc(var(--global--spacing-horizontal) - var(--button--border-width));
 	--button--padding-horizontal: var(--global--spacing-horizontal);

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -102,7 +102,7 @@
 	--button--font-size: var(--global--font-size-base);
 	--button--font-weight: normal;
 	--button--line-height: 1;
-	--button--border-width: 1px;
+	--button--border-width: 2px;
 	--button--border-radius: 4px;
 	--button--padding-vertical: calc(var(--global--spacing-horizontal) - var(--button--border-width));
 	--button--padding-horizontal: var(--global--spacing-horizontal);

--- a/varya/assets/sass/blocks/button/_config.scss
+++ b/varya/assets/sass/blocks/button/_config.scss
@@ -15,7 +15,7 @@
 	--button--line-height: 1;
 
 	// Borders
-	--button--border-width: 1px;
+	--button--border-width: 2px;
 	--button--border-radius: 4px;
 
 	// Spacing

--- a/varya/assets/sass/blocks/button/_editor.scss
+++ b/varya/assets/sass/blocks/button/_editor.scss
@@ -1,42 +1,36 @@
-.wp-block-button {
+.wp-block-button__link {
 
-	// Default Style
-	.wp-block-button__link {
-		color: var(--button--color-text);
-		font-weight: var(--button--font-weight);
-		font-family: var(--button--font-family);
-		font-size: var(--button--font-size);
-		line-height: var(--button--line-height);
-		background-color: var(--button--color-background);
-		border-radius: var(--button--border-radius);
-		padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+	color: var(--button--color-text);
+	font-weight: var(--button--font-weight);
+	font-family: var(--button--font-family);
+	font-size: var(--button--font-size);
+	line-height: var(--button--line-height);
+	background-color: var(--button--color-background);
+	border-radius: var(--button--border-radius);
+	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 
-		&:hover,
-		&:focus,
-		&.has-focus {
-			color: var(--button--color-text-hover);
-			background-color: var(--button--color-background-hover);
-		}
+	&:hover,
+	&:focus,
+	&.has-focus {
+		color: var(--button--color-text-hover);
+		background-color: var(--button--color-background-hover);
 	}
 
 	// Outline Style
 	&.is-style-outline {
+		color: var(--button--color-background);
+		background: transparent;
+		border: 2px solid currentcolor;
 
-		.wp-block-button__link {
-			color: var(--button--color-background);
-			background: transparent;
-			border: 2px solid currentcolor;
-
-			&:hover,
-			&:focus,
-			&.has-focus {
-				color: var(--button--color-background-hover);
-			}
+		&:hover,
+		&:focus,
+		&.has-focus {
+			color: var(--button--color-background-hover);
 		}
 	}
 
 	// Squared Style
-	&.is-style-squared .wp-block-button__link {
+	&.is-style-squared {
 		border-radius: 0;
 	}
 }

--- a/varya/assets/sass/blocks/button/_editor.scss
+++ b/varya/assets/sass/blocks/button/_editor.scss
@@ -17,20 +17,16 @@
 	}
 
 	// Outline Style
-	&.is-style-outline {
+	&.is-style-outline,
+	.is-style-outline & {
 		color: var(--button--color-background);
 		background: transparent;
 		border: 2px solid currentcolor;
-
-		&:hover,
-		&:focus,
-		&.has-focus {
-			color: var(--button--color-background-hover);
-		}
 	}
 
 	// Squared Style
-	&.is-style-squared {
+	&.is-style-squared,
+	.is-style-squared & {
 		border-radius: 0;
 	}
 }

--- a/varya/assets/sass/blocks/button/_style.scss
+++ b/varya/assets/sass/blocks/button/_style.scss
@@ -22,7 +22,8 @@ input[type="submit"],
 
 	// Outline Style
 	&.is-style-outline {
-
+	
+		&.wp-block-button__link,
 		.wp-block-button__link {
 			color: var(--button--color-background);
 			background: transparent;

--- a/varya/assets/sass/blocks/button/_style.scss
+++ b/varya/assets/sass/blocks/button/_style.scss
@@ -22,6 +22,7 @@ input[type="submit"],
 
 	// Outline Style
 	&.is-style-outline {
+		border: none;
 	
 		&.wp-block-button__link,
 		.wp-block-button__link {

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -102,7 +102,7 @@ body {
 	--button--font-size: var(--global--font-size-base);
 	--button--font-weight: normal;
 	--button--line-height: 1;
-	--button--border-width: 1px;
+	--button--border-width: 2px;
 	--button--border-radius: 4px;
 	--button--padding-vertical: calc(var(--global--spacing-horizontal) - var(--button--border-width));
 	--button--padding-horizontal: var(--global--spacing-horizontal);

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -102,7 +102,7 @@
 	--button--font-size: var(--global--font-size-base);
 	--button--font-weight: normal;
 	--button--line-height: 1;
-	--button--border-width: 1px;
+	--button--border-width: 2px;
 	--button--border-radius: 4px;
 	--button--padding-vertical: calc(var(--global--spacing-horizontal) - var(--button--border-width));
 	--button--padding-horizontal: var(--global--spacing-horizontal);

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -1229,6 +1229,7 @@ button[data-load-more-btn],
 	line-height: var(--button--line-height);
 }
 
+.wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: var(--button--color-background);
 	background: transparent;
@@ -1236,11 +1237,15 @@ button[data-load-more-btn],
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
+.wp-block-button.is-style-outline.wp-block-button__link:active,
 .wp-block-button.is-style-outline .wp-block-button__link:active {
 	color: var(--button--color-background);
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link:hover, .wp-block-button.is-style-outline .wp-block-button__link:focus, .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+.wp-block-button.is-style-outline.wp-block-button__link:hover, .wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:hover,
+.wp-block-button.is-style-outline .wp-block-button__link:focus,
+.wp-block-button.is-style-outline .wp-block-button__link.has-focus {
 	color: var(--button--color-background-hover);
 }
 

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -1229,6 +1229,10 @@ button[data-load-more-btn],
 	line-height: var(--button--line-height);
 }
 
+.wp-block-button.is-style-outline {
+	border: none;
+}
+
 .wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: var(--button--color-background);

--- a/varya/style.css
+++ b/varya/style.css
@@ -1237,6 +1237,7 @@ button[data-load-more-btn],
 	line-height: var(--button--line-height);
 }
 
+.wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: var(--button--color-background);
 	background: transparent;
@@ -1244,11 +1245,15 @@ button[data-load-more-btn],
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
+.wp-block-button.is-style-outline.wp-block-button__link:active,
 .wp-block-button.is-style-outline .wp-block-button__link:active {
 	color: var(--button--color-background);
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link:hover, .wp-block-button.is-style-outline .wp-block-button__link:focus, .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+.wp-block-button.is-style-outline.wp-block-button__link:hover, .wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:hover,
+.wp-block-button.is-style-outline .wp-block-button__link:focus,
+.wp-block-button.is-style-outline .wp-block-button__link.has-focus {
 	color: var(--button--color-background-hover);
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -1237,6 +1237,10 @@ button[data-load-more-btn],
 	line-height: var(--button--line-height);
 }
 
+.wp-block-button.is-style-outline {
+	border: none;
+}
+
 .wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: var(--button--color-background);


### PR DESCRIPTION
Plugin versions of Gutenberg change button markup inside of the editor. Previously it looked like this: 

```
<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link">My button</a></div>
<!-- /wp:button -->
```

Now, the button markup looks like this: 

```
<!-- wp:button -->
<a class="wp-block-button wp-block-button__link">My button</a>
<!-- /wp:button -->
```

Notice that there's no wrapping div anymore, and that the `wp-block-button__link` class has been relocated up to the same level as `wp-block-button`. As a result, the theme's current button styles do not work get inherited correctly in the editor: 

<img width="741" alt="Screen Shot 2020-04-13 at 10 23 05 AM" src="https://user-images.githubusercontent.com/1202812/79130322-c69bd080-7d74-11ea-8d9c-f409b6ec5aa4.png">

In order to fix this while still preserving compatibility with older versions of Gutenberg, we need to _only_ target `wp-block-button__link`. This PR makes that change, and gets the editor styles for these buttons working again: 

<img width="708" alt="Screen Shot 2020-04-13 at 10 24 13 AM" src="https://user-images.githubusercontent.com/1202812/79130408-eb904380-7d74-11ea-8fc1-5691110474ef.png">

---

To test, please ensure that you try this against the current plugin version of Gutenberg (7.8.1), and also with the plugin deactivated. 