### PR TITLE
Varya: Button editor styles Gutenberg 7.9rc-1 patch

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -377,6 +377,13 @@ object {
 	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+	border: none;
+	box-shadow: none;
+	display: inline-block;
+	margin: 0;
+	text-align: center;
+	text-decoration: none;
+	overflow-wrap: break-word;
 }
 
 .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -121,6 +121,13 @@ body[class*="woocommerce"] #page .site-content .woocommerce.widget_shopping_cart
 	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+	border: none;
+	box-shadow: none;
+	display: inline-block;
+	margin: 0;
+	text-align: center;
+	text-decoration: none;
+	overflow-wrap: break-word;
 }
 
 body[class*="woocommerce"] #page .site-content #respond input#submit:before,

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -121,6 +121,13 @@ body[class*="woocommerce"] #page .site-content .woocommerce.widget_shopping_cart
 	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+	border: none;
+	box-shadow: none;
+	display: inline-block;
+	margin: 0;
+	text-align: center;
+	text-decoration: none;
+	overflow-wrap: break-word;
 }
 
 body[class*="woocommerce"] #page .site-content #respond input#submit:before,

--- a/varya/assets/sass/base/_extends.scss
+++ b/varya/assets/sass/base/_extends.scss
@@ -14,6 +14,13 @@
 	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+	border: none;
+	box-shadow: none;
+	display: inline-block;
+	margin: 0;
+	text-align: center;
+	text-decoration: none;
+	overflow-wrap: break-word;
 
 	&:active {
 		color: var(--button--color-text-active);

--- a/varya/assets/sass/blocks/button/_style.scss
+++ b/varya/assets/sass/blocks/button/_style.scss
@@ -20,6 +20,10 @@ input[type="submit"],
 	font-weight: var(--button--font-weight);
 	line-height: var(--button--line-height);
 
+	&:not(.wp-block-button__link){
+		padding: 0;
+	}
+
 	// Outline Style
 	&.is-style-outline {
 		color: inherit;

--- a/varya/assets/sass/blocks/button/_style.scss
+++ b/varya/assets/sass/blocks/button/_style.scss
@@ -22,6 +22,8 @@ input[type="submit"],
 
 	// Outline Style
 	&.is-style-outline {
+		color: inherit;
+		border: none;
 	
 		&.wp-block-button__link,
 		.wp-block-button__link {
@@ -40,6 +42,7 @@ input[type="submit"],
 				color: var(--button--color-background-hover);
 			}
 		}
+
 	}
 
 	// Squared Style

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -354,6 +354,13 @@ input[type="submit"],
 	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+	border: none;
+	box-shadow: none;
+	display: inline-block;
+	margin: 0;
+	text-align: center;
+	text-decoration: none;
+	overflow-wrap: break-word;
 }
 
 button[data-load-more-btn]:before,
@@ -1139,6 +1146,13 @@ input[type="submit"],
 	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+	border: none;
+	box-shadow: none;
+	display: inline-block;
+	margin: 0;
+	text-align: center;
+	text-decoration: none;
+	overflow-wrap: break-word;
 }
 
 button[data-load-more-btn]:before,
@@ -1227,6 +1241,11 @@ button[data-load-more-btn],
 	font-size: var(--button--font-size);
 	font-weight: var(--button--font-weight);
 	line-height: var(--button--line-height);
+}
+
+.wp-block-button.is-style-outline {
+	color: inherit;
+	border: none;
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link,

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -1243,6 +1243,10 @@ button[data-load-more-btn],
 	line-height: var(--button--line-height);
 }
 
+.wp-block-button:not(.wp-block-button__link) {
+	padding: 0;
+}
+
 .wp-block-button.is-style-outline {
 	color: inherit;
 	border: none;

--- a/varya/style.css
+++ b/varya/style.css
@@ -362,6 +362,13 @@ input[type="submit"],
 	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+	border: none;
+	box-shadow: none;
+	display: inline-block;
+	margin: 0;
+	text-align: center;
+	text-decoration: none;
+	overflow-wrap: break-word;
 }
 
 button[data-load-more-btn]:before,
@@ -1147,6 +1154,13 @@ input[type="submit"],
 	border-width: 0;
 	text-decoration: none;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+	border: none;
+	box-shadow: none;
+	display: inline-block;
+	margin: 0;
+	text-align: center;
+	text-decoration: none;
+	overflow-wrap: break-word;
 }
 
 button[data-load-more-btn]:before,
@@ -1235,6 +1249,11 @@ button[data-load-more-btn],
 	font-size: var(--button--font-size);
 	font-weight: var(--button--font-weight);
 	line-height: var(--button--line-height);
+}
+
+.wp-block-button.is-style-outline {
+	color: inherit;
+	border: none;
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link,

--- a/varya/style.css
+++ b/varya/style.css
@@ -1251,6 +1251,10 @@ button[data-load-more-btn],
 	line-height: var(--button--line-height);
 }
 
+.wp-block-button:not(.wp-block-button__link) {
+	padding: 0;
+}
+
 .wp-block-button.is-style-outline {
 	color: inherit;
 	border: none;


### PR DESCRIPTION
This PR is a test to demonstrate that adding certain default button block styles from Gutenberg resolves [the front-end issue described here](https://github.com/Automattic/themes-workspace/pull/75#issuecomment-612973086). 

**Before**
<img width="421" alt="Screen Shot 2020-04-13 at 12 23 13 PM" src="https://user-images.githubusercontent.com/1202812/79137933-a292bc00-7d81-11ea-8265-26e236ace85d.png">

**After**
<img width="421" alt="Screen Shot 2020-04-13 at 3 16 26 PM" src="https://user-images.githubusercontent.com/5375500/79152197-c530cf00-7d99-11ea-951a-fc52ecb16902.png">
