### PR TITLE
Varya: Add TRT caption classes.

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -177,7 +177,10 @@ blockquote.alignright footer {
 	letter-spacing: var(--global--letter-spacing-xs);
 }
 
-figcaption {
+/* Media captions */
+figcaption,
+.wp-caption,
+.wp-caption-text {
 	color: var(--global--color-foreground-light);
 	font-size: var(--global--font-size-xs);
 	line-height: var(--global--font-line-height-xs);
@@ -187,7 +190,13 @@ figcaption {
 }
 
 .alignleft figcaption,
-.alignright figcaption {
+.alignright figcaption, .alignleft
+.wp-caption,
+.alignright
+.wp-caption, .alignleft
+.wp-caption-text,
+.alignright
+.wp-caption-text {
 	margin-bottom: 0;
 }
 

--- a/varya/assets/sass/elements/_media.scss
+++ b/varya/assets/sass/elements/_media.scss
@@ -1,8 +1,7 @@
-figure {
-
-}
-
-figcaption {
+/* Media captions */
+figcaption,
+.wp-caption,
+.wp-caption-text {
 	color: var(--global--color-foreground-light);
 	font-size: var(--global--font-size-xs);
 	line-height: var(--global--font-line-height-xs);

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -918,7 +918,10 @@ input[type=checkbox] + label {
 	line-height: 1em;
 }
 
-figcaption {
+/* Media captions */
+figcaption,
+.wp-caption,
+.wp-caption-text {
 	color: var(--global--color-foreground-light);
 	font-size: var(--global--font-size-xs);
 	line-height: var(--global--font-line-height-xs);
@@ -928,7 +931,13 @@ figcaption {
 }
 
 .alignleft figcaption,
-.alignright figcaption {
+.alignright figcaption, .alignleft
+.wp-caption,
+.alignright
+.wp-caption, .alignleft
+.wp-caption-text,
+.alignright
+.wp-caption-text {
 	margin-bottom: 0;
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -926,7 +926,10 @@ input[type=checkbox] + label {
 	line-height: 1em;
 }
 
-figcaption {
+/* Media captions */
+figcaption,
+.wp-caption,
+.wp-caption-text {
 	color: var(--global--color-foreground-light);
 	font-size: var(--global--font-size-xs);
 	line-height: var(--global--font-line-height-xs);
@@ -936,7 +939,13 @@ figcaption {
 }
 
 .alignleft figcaption,
-.alignright figcaption {
+.alignright figcaption, .alignleft
+.wp-caption,
+.alignright
+.wp-caption, .alignleft
+.wp-caption-text,
+.alignright
+.wp-caption-text {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
- Adds the `figcaption` style to the `.wp-caption` and `.wp-caption-text` classes.
- Also removes an empty `figure` selector.

Fixes: #73 