### PR TITLE
Varya: Add initial readme.txt to pass TRT requirements.

### DIFF
--- a/varya/assets/sass/style.scss
+++ b/varya/assets/sass/style.scss
@@ -11,11 +11,23 @@ License URI: LICENSE
 Text Domain: varya
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready
 
-This theme, like WordPress, is licensed under the GPL.
-Use it to make something cool, have fun, and share what you've learned with others.
+Varya WordPress Theme, (C) 2020 Automattic, Inc.
+Varya is distributed under the terms of the GNU GPL.
 
-varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+Varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
 Underscores is distributed under the terms of the GNU GPL v2 or later.
+
+Varya bundles the following third-party resources:
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/

--- a/varya/assets/sass/style.scss
+++ b/varya/assets/sass/style.scss
@@ -24,16 +24,28 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
-Varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
-Underscores is distributed under the terms of the GNU GPL v2 or later.
+Varya is derived from Twenty Nineteen. 2018-2020 WordPress.org
+Twenty Nineteen is distributed under the terms of the GNU GPL v2 or later.
 
-Varya bundles the following third-party resources:
+Varya is also based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
+Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
-Social Icons License: GNU GPL v2 or later.
+Varya bundles the following third-party resources:
+
+Social Icons
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Source: WordPress Social Link Block (See wp-includes\blocks\social-link.php)
+
+Code from Twenty Twenty
+Copyright (C) 2020 WordPress.org
+License: GPLv2
+Source: https://wordpress.org/themes/twentytwenty/
+Included as part of the following classes and functions:
+- sanitize_select()
 */
 
 // Layout

--- a/varya/readme.txt
+++ b/varya/readme.txt
@@ -18,12 +18,9 @@ Varya is a parent-theme with a built-in styling system for quickly creating Gute
 
 When you reduce a theme design down to a set of systematic design decisions, you end up with something called a _Style Guide_. The Varya system works by taking the rules of a Style Guide and expressing them through carefully placed variables or _design tokens_ that influence the appearance of a WordPress site. This unifies the design decisions needed to style the aesthetic appearance of Gutenberg Blocks, the theme Header + Footer areas, WooCommerce, Jetpack and more. It also syncs styles between the editor and the frontend so that you don’t need to hand-write CSS for both. This greatly speeds up the Gutenberg theme development process and reduces the amount of manual styling that typically goes into developing a theme.
 
-= What controls does the system come with? =
+= How does it work? =
 
-- **Fonts** - Font-family, size, weight, and line-height rules.
-- **Colors** - Primary, secondary, background, foreground and border colors.
-- **Spacing** - A default 8px vertical rhythm between all blocks and major components. It also includes utility spacing classes for negative margins.
-- **Responsive Logic** - Built-in responsive behavior across Blocks and Components.
+Visit the Varya GitHub repo for usage and setup instructions: https://github.com/Automattic/themes-workspace/tree/master/varya
 
 == Changelog ==
 

--- a/varya/readme.txt
+++ b/varya/readme.txt
@@ -1,0 +1,34 @@
+=== Varya ===
+Contributors: (Should only contain WordPress.org usernames.)
+Requires at least: 5.0
+Tested up to: 5.2
+Requires PHP: 5.6
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+A theme for creating Gutenberg-ready themes quickly and easily.
+
+== Description ==
+
+Varya is a parent-theme with a built-in styling system for quickly creating Gutenberg-ready child-themes for WordPress.
+
+== Frequently Asked Questions ==
+
+= What does it do? =
+
+When you reduce a theme design down to a set of systematic design decisions, you end up with something called a _Style Guide_. The Varya system works by taking the rules of a Style Guide and expressing them through carefully placed variables or _design tokens_ that influence the appearance of a WordPress site. This unifies the design decisions needed to style the aesthetic appearance of Gutenberg Blocks, the theme Header + Footer areas, WooCommerce, Jetpack and more. It also syncs styles between the editor and the frontend so that you don’t need to hand-write CSS for both. This greatly speeds up the Gutenberg theme development process and reduces the amount of manual styling that typically goes into developing a theme.
+
+= What controls does the system come with? =
+
+- **Fonts** - Font-family, size, weight, and line-height rules.
+- **Colors** - Primary, secondary, background, foreground and border colors.
+- **Spacing** - A default 8px vertical rhythm between all blocks and major components. It also includes utility spacing classes for negative margins.
+- **Responsive Logic** - Built-in responsive behavior across Blocks and Components.
+
+== Changelog ==
+
+= 1.0 =
+* Initial release
+
+== Resources ==
+* normalize.css © Nicolas Gallagher and Jonathan Neal, MIT

--- a/varya/readme.txt
+++ b/varya/readme.txt
@@ -32,13 +32,25 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
-Varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
-Underscores is distributed under the terms of the GNU GPL v2 or later.
+Varya is derived from Twenty Nineteen. 2018-2020 WordPress.org
+Twenty Nineteen is distributed under the terms of the GNU GPL v2 or later.
 
-Varya bundles the following third-party resources:
+Varya is also based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
+Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
-Social Icons License: GNU GPL v2 or later.
+Varya bundles the following third-party resources:
+
+Social Icons
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Source: WordPress Social Link Block (See wp-includes\blocks\social-link.php)
+
+Code from Twenty Twenty
+Copyright (C) 2020 WordPress.org
+License: GPLv2
+Source: https://wordpress.org/themes/twentytwenty/
+Included as part of the following classes and functions:
+- sanitize_select()

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3,7 +3,7 @@ Theme Name: Varya
 Theme URI: https://github.com/Automattic/theme-workspace/varya
 Author: Dotorg Themes
 Author URI: https://wordpress.org/
-Description: A design system for WordPress sites built with Gutenberg.
+Description: A simple, text-driven, single-column theme.
 Requires at least: WordPress 4.9.6
 Version: 1.0
 License: GNU General Public License v2 or later
@@ -11,11 +11,23 @@ License URI: LICENSE
 Text Domain: varya
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready
 
-This theme, like WordPress, is licensed under the GPL.
-Use it to make something cool, have fun, and share what you've learned with others.
+Varya WordPress Theme, (C) 2020 Automattic, Inc.
+Varya is distributed under the terms of the GNU GPL.
 
-varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+Varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
 Underscores is distributed under the terms of the GNU GPL v2 or later.
+
+Varya bundles the following third-party resources:
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3,7 +3,7 @@ Theme Name: Varya
 Theme URI: https://github.com/Automattic/theme-workspace/varya
 Author: Dotorg Themes
 Author URI: https://wordpress.org/
-Description: A simple, text-driven, single-column theme.
+Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
 Version: 1.0
 License: GNU General Public License v2 or later
@@ -24,16 +24,28 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
-Varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
-Underscores is distributed under the terms of the GNU GPL v2 or later.
+Varya is derived from Twenty Nineteen. 2018-2020 WordPress.org
+Twenty Nineteen is distributed under the terms of the GNU GPL v2 or later.
 
-Varya bundles the following third-party resources:
+Varya is also based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
+Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
-Social Icons License: GNU GPL v2 or later.
+Varya bundles the following third-party resources:
+
+Social Icons
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Source: WordPress Social Link Block (See wp-includes\blocks\social-link.php)
+
+Code from Twenty Twenty
+Copyright (C) 2020 WordPress.org
+License: GPLv2
+Source: https://wordpress.org/themes/twentytwenty/
+Included as part of the following classes and functions:
+- sanitize_select()
 */
 /**
  * Layout

--- a/varya/style.css
+++ b/varya/style.css
@@ -24,16 +24,28 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
-Varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
-Underscores is distributed under the terms of the GNU GPL v2 or later.
+Varya is derived from Twenty Nineteen. 2018-2020 WordPress.org
+Twenty Nineteen is distributed under the terms of the GNU GPL v2 or later.
 
-Varya bundles the following third-party resources:
+Varya is also based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
+Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
-Social Icons License: GNU GPL v2 or later.
+Varya bundles the following third-party resources:
+
+Social Icons
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Source: WordPress Social Link Block (See wp-includes\blocks\social-link.php)
+
+Code from Twenty Twenty
+Copyright (C) 2020 WordPress.org
+License: GPLv2
+Source: https://wordpress.org/themes/twentytwenty/
+Included as part of the following classes and functions:
+- sanitize_select()
 */
 /**
  * Layout

--- a/varya/style.css
+++ b/varya/style.css
@@ -3,7 +3,7 @@ Theme Name: Varya
 Theme URI: https://github.com/Automattic/theme-workspace/varya
 Author: Dotorg Themes
 Author URI: https://wordpress.org/
-Description: A design system for WordPress sites built with Gutenberg.
+Description: A simple, text-driven, single-column theme.
 Requires at least: WordPress 4.9.6
 Version: 1.0
 License: GNU General Public License v2 or later
@@ -11,11 +11,23 @@ License URI: LICENSE
 Text Domain: varya
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready
 
-This theme, like WordPress, is licensed under the GPL.
-Use it to make something cool, have fun, and share what you've learned with others.
+Varya WordPress Theme, (C) 2020 Automattic, Inc.
+Varya is distributed under the terms of the GNU GPL.
 
-varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+Varya is based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
 Underscores is distributed under the terms of the GNU GPL v2 or later.
+
+Varya bundles the following third-party resources:
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/

--- a/varya/style.css
+++ b/varya/style.css
@@ -3,7 +3,7 @@ Theme Name: Varya
 Theme URI: https://github.com/Automattic/theme-workspace/varya
 Author: Dotorg Themes
 Author URI: https://wordpress.org/
-Description: A simple, text-driven, single-column theme.
+Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
 Version: 1.0
 License: GNU General Public License v2 or later


### PR DESCRIPTION
This is a first pass at adding a readme.txt file to pass the TRT requirements. I mostly just borrowed copy from the markdown version of this file, but let’s discuss what should actually go in here below. 

Fixes: #74 