### PR TITLE
Varya: Refine mobile heading spacing

### DIFF
--- a/varya/assets/sass/structure/_vertical-margins.scss
+++ b/varya/assets/sass/structure/_vertical-margins.scss
@@ -27,12 +27,20 @@
 }
 
 .site-header {
-	padding-top: calc(2 * var(--global--spacing-vertical));
-	padding-bottom: calc(2 * var(--global--spacing-vertical));
+	padding-top: calc(3 * var(--global--spacing-vertical));
+	padding-bottom: calc(3 * var(--global--spacing-vertical));
+
+	&.has-main-navigation {
+		padding-top: calc(4 * var(--global--spacing-vertical));
+	}
 
 	@include media(mobile) {
 		padding-top: calc(3 * var(--global--spacing-vertical));
 		padding-bottom: calc(3 * var(--global--spacing-vertical));
+
+		&.has-main-navigation {
+			padding-top: calc(3 * var(--global--spacing-vertical));
+		}
 	}
 }
 

--- a/varya/assets/sass/structure/_vertical-margins.scss
+++ b/varya/assets/sass/structure/_vertical-margins.scss
@@ -30,7 +30,7 @@
 	padding-top: calc(3 * var(--global--spacing-vertical));
 	padding-bottom: calc(3 * var(--global--spacing-vertical));
 
-	&.has-main-navigation {
+	.has-main-navigation & {
 		padding-top: calc(4 * var(--global--spacing-vertical));
 	}
 
@@ -38,7 +38,7 @@
 		padding-top: calc(3 * var(--global--spacing-vertical));
 		padding-bottom: calc(3 * var(--global--spacing-vertical));
 
-		&.has-main-navigation {
+		.has-main-navigation & {
 			padding-top: calc(3 * var(--global--spacing-vertical));
 		}
 	}

--- a/varya/header.php
+++ b/varya/header.php
@@ -23,7 +23,7 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varya' ); ?></a>
 
-		<header id="masthead" class="site-header default-max-width <?php if ( has_nav_menu( 'primary' ) ) : echo esc_attr( 'has-main-navigation' ); endif; ?>">
+		<header id="masthead" class="site-header default-max-width">
 
 			<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 

--- a/varya/header.php
+++ b/varya/header.php
@@ -23,7 +23,7 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varya' ); ?></a>
 
-		<header id="masthead" class="site-header default-max-width">
+		<header id="masthead" class="site-header default-max-width <?php if ( has_nav_menu( 'primary' ) ) : echo esc_attr( 'has-main-navigation' ); endif; ?>">
 
 			<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 

--- a/varya/inc/template-functions.php
+++ b/varya/inc/template-functions.php
@@ -40,6 +40,11 @@ function varya_body_classes( $classes ) {
 		$classes[] = 'image-filters-enabled';
 	}
 
+	// Add a body class if main navigation is active.
+	if ( has_nav_menu( 'primary' ) ) {
+		$classes[] = 'has-main-navigation'; 
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'varya_body_classes' );

--- a/varya/inc/template-functions.php
+++ b/varya/inc/template-functions.php
@@ -35,11 +35,6 @@ function varya_body_classes( $classes ) {
 		$classes[] = 'hfeed';
 	}
 
-	// Adds a class if image filters are enabled.
-	if ( varya_image_filters_enabled() ) {
-		$classes[] = 'image-filters-enabled';
-	}
-
 	// Add a body class if main navigation is active.
 	if ( has_nav_menu( 'primary' ) ) {
 		$classes[] = 'has-main-navigation'; 
@@ -123,13 +118,6 @@ add_filter( 'get_the_archive_title', 'varya_get_the_archive_title' );
  */
 function varya_can_show_post_thumbnail() {
 	return apply_filters( 'varya_can_show_post_thumbnail', ! post_password_required() && ! is_attachment() && has_post_thumbnail() );
-}
-
-/**
- * Returns true if image filters are enabled on the theme options.
- */
-function varya_image_filters_enabled() {
-	return 0 !== get_theme_mod( 'image_filter', 1 );
 }
 
 /**

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -179,14 +179,21 @@ Source: WordPress Social Link Block (See wp-includes\blocks\social-link.php)
 }
 
 .site-header {
-	padding-top: calc(2 * var(--global--spacing-vertical));
-	padding-bottom: calc(2 * var(--global--spacing-vertical));
+	padding-top: calc(3 * var(--global--spacing-vertical));
+	padding-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
+.site-header.has-main-navigation {
+	padding-top: calc(4 * var(--global--spacing-vertical));
 }
 
 @media only screen and (min-width: 482px) {
 	.site-header {
 		padding-top: calc(3 * var(--global--spacing-vertical));
 		padding-bottom: calc(3 * var(--global--spacing-vertical));
+	}
+	.site-header.has-main-navigation {
+		padding-top: calc(3 * var(--global--spacing-vertical));
 	}
 }
 

--- a/varya/style.css
+++ b/varya/style.css
@@ -191,7 +191,7 @@ Source: WordPress Social Link Block (See wp-includes\blocks\social-link.php)
 	padding-bottom: calc(3 * var(--global--spacing-vertical));
 }
 
-.site-header.has-main-navigation {
+.has-main-navigation .site-header {
 	padding-top: calc(4 * var(--global--spacing-vertical));
 }
 
@@ -200,7 +200,7 @@ Source: WordPress Social Link Block (See wp-includes\blocks\social-link.php)
 		padding-top: calc(3 * var(--global--spacing-vertical));
 		padding-bottom: calc(3 * var(--global--spacing-vertical));
 	}
-	.site-header.has-main-navigation {
+	.has-main-navigation .site-header {
 		padding-top: calc(3 * var(--global--spacing-vertical));
 	}
 }

--- a/varya/style.css
+++ b/varya/style.css
@@ -187,14 +187,21 @@ Source: WordPress Social Link Block (See wp-includes\blocks\social-link.php)
 }
 
 .site-header {
-	padding-top: calc(2 * var(--global--spacing-vertical));
-	padding-bottom: calc(2 * var(--global--spacing-vertical));
+	padding-top: calc(3 * var(--global--spacing-vertical));
+	padding-bottom: calc(3 * var(--global--spacing-vertical));
+}
+
+.site-header.has-main-navigation {
+	padding-top: calc(4 * var(--global--spacing-vertical));
 }
 
 @media only screen and (min-width: 482px) {
 	.site-header {
 		padding-top: calc(3 * var(--global--spacing-vertical));
 		padding-bottom: calc(3 * var(--global--spacing-vertical));
+	}
+	.site-header.has-main-navigation {
+		padding-top: calc(3 * var(--global--spacing-vertical));
 	}
 }
 


### PR DESCRIPTION
This PR adjusts the spacing of the site header on small screens. It adds a little space to ensure that the whitespace balance is a little more in line with the way it is on desktop, and it also introduces a little extra top margin if a main navigation exists, so that the logo and tagline appear more centered vertically.

Before: 

Menu|No Menu
----|----
![dotorgthemes test_ (2)](https://user-images.githubusercontent.com/1202812/79226598-a891a700-7e2c-11ea-9ef9-b399f141dc0e.png)|![dotorgthemes test_ (3)](https://user-images.githubusercontent.com/1202812/79226607-a9c2d400-7e2c-11ea-87ba-bff10c1baeac.png)

After:

Menu|No Menu
----|----
![dotorgthemes test_](https://user-images.githubusercontent.com/1202812/79226644-b6dfc300-7e2c-11ea-82c9-3eea1f0e2f41.png)|![dotorgthemes test_ (1)](https://user-images.githubusercontent.com/1202812/79226646-b7785980-7e2c-11ea-8c75-b5fd515b1a10.png)
