### PR TITLE
Use the theme's max-width in the editor

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -121,6 +121,10 @@ a {
 	max-width: var(--responsive--aligndefault-width);
 }
 
+.wp-block[data-align="wide"], .wp-block.alignwide {
+	max-width: var(--responsive--alignwide-width);
+}
+
 div[data-type="core/button"] {
 	display: block;
 }

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -30,11 +30,18 @@ a {
 	cursor: pointer;
 }
 
-// Gutenberg injects a rule that limits the max width of .wp-block to 580px
-// This line overrides it to use the responsive spacing rules for default width content
 .wp-block {
+
+	// Gutenberg injects a rule that limits the max width of .wp-block to 580px
+	// This line overrides it to use the responsive spacing rules for default width content
 	&:not([data-align="full"]):not([data-align="wide"]){
 		max-width: var(--responsive--aligndefault-width);
+	}
+
+	// Use the theme's max-width for wide alignment.
+	&[data-align="wide"],
+	&.alignwide {
+		max-width: var(--responsive--alignwide-width);
 	}
 }
 


### PR DESCRIPTION
Before: 

![Screen Shot 2020-04-15 at 2 18 19 PM](https://user-images.githubusercontent.com/1202812/79374746-8a5ba200-7f25-11ea-965b-8c8eaac05626.png)

After:

![Screen Shot 2020-04-15 at 2 29 10 PM](https://user-images.githubusercontent.com/1202812/79374752-8d569280-7f25-11ea-85d5-e86e917e26c0.png)
