### PR TITLE
Varya: Adjust search form layout

### DIFF
--- a/varya/assets/sass/elements/_forms.scss
+++ b/varya/assets/sass/elements/_forms.scss
@@ -41,3 +41,16 @@ input[type=checkbox] + label {
 	margin-left: 0.5em;
 	line-height: 1em;
 }
+
+.search-form {
+	display: flex;
+	margin-bottom: var(--global--spacing-vertical);
+	> label {
+		display: flex;
+		margin-right: var(--global--spacing-horizontal);
+		width: 100%;
+		.search-field {
+			width: 100%;
+		}
+	}
+}

--- a/varya/assets/sass/elements/_forms.scss
+++ b/varya/assets/sass/elements/_forms.scss
@@ -44,7 +44,6 @@ input[type=checkbox] + label {
 
 .search-form {
 	display: flex;
-	margin-bottom: var(--global--spacing-vertical);
 	> label {
 		display: flex;
 		margin-right: var(--global--spacing-horizontal);

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -925,6 +925,20 @@ input[type=checkbox] + label {
 	line-height: 1em;
 }
 
+.search-form {
+	display: flex;
+}
+
+.search-form > label {
+	display: flex;
+	margin-left: var(--global--spacing-horizontal);
+	width: 100%;
+}
+
+.search-form > label .search-field {
+	width: 100%;
+}
+
 /* Media captions */
 figcaption,
 .wp-caption,

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -927,6 +927,7 @@ input[type=checkbox] + label {
 
 .search-form {
 	display: flex;
+	margin-bottom: var(--global--spacing-vertical);
 }
 
 .search-form > label {

--- a/varya/style.css
+++ b/varya/style.css
@@ -935,7 +935,6 @@ input[type=checkbox] + label {
 
 .search-form {
 	display: flex;
-	margin-bottom: var(--global--spacing-vertical);
 }
 
 .search-form > label {

--- a/varya/style.css
+++ b/varya/style.css
@@ -933,6 +933,21 @@ input[type=checkbox] + label {
 	line-height: 1em;
 }
 
+.search-form {
+	display: flex;
+	margin-bottom: var(--global--spacing-vertical);
+}
+
+.search-form > label {
+	display: flex;
+	margin-right: var(--global--spacing-horizontal);
+	width: 100%;
+}
+
+.search-form > label .search-field {
+	width: 100%;
+}
+
 /* Media captions */
 figcaption,
 .wp-caption,


### PR DESCRIPTION
Adjusts the layout of the `.search-form`, which shows up on a 404 page right now or appears when you activate the search widget. #89 

**Before**
<img width="657" alt="Screen Shot 2020-04-16 at 9 52 45 AM" src="https://user-images.githubusercontent.com/5375500/79464573-3a81e700-7fc8-11ea-82d2-245eb93f5346.png">

**After**
<img width="690" alt="Screen Shot 2020-04-16 at 9 53 01 AM" src="https://user-images.githubusercontent.com/5375500/79464584-3eae0480-7fc8-11ea-88be-9237ea5b39f5.png">
