### PR TITLE
Varya: Use theme fonts for initial paragraph inserter

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -125,6 +125,11 @@ a {
 	max-width: var(--responsive--alignwide-width);
 }
 
+.wp-block.block-editor-default-block-appender > textarea {
+	font-family: var(--global--font-secondary);
+	font-size: var(--global--font-size-md);
+}
+
 div[data-type="core/button"] {
 	display: block;
 }

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -43,6 +43,11 @@ a {
 	&.alignwide {
 		max-width: var(--responsive--alignwide-width);
 	}
+
+	&.block-editor-default-block-appender > textarea {
+		font-family: var(--global--font-secondary);
+		font-size: var(--global--font-size-md);
+	}
 }
 
 div[data-type="core/button"] {

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -927,7 +927,6 @@ input[type=checkbox] + label {
 
 .search-form {
 	display: flex;
-	margin-bottom: var(--global--spacing-vertical);
 }
 
 .search-form > label {


### PR DESCRIPTION
Fixes #98. 

I put this in `sass/base/_editor.scss` because it feels related to the base styles of the editor, since this only happens on initial render. 

**Before**
<img width="664" alt="Screen Shot 2020-04-17 at 11 38 29 AM" src="https://user-images.githubusercontent.com/5375500/79587092-fc57f680-809f-11ea-9a8d-6b0bc4e314fa.png">

**After**
<img width="655" alt="Screen Shot 2020-04-17 at 11 32 34 AM" src="https://user-images.githubusercontent.com/5375500/79587036-ed714400-809f-11ea-9196-6fe635f7287e.png">
