### PR TITLE
Varya: update pagination treatment and utilize existing pagination variables

### DIFF
--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -208,6 +208,12 @@
 	--footer--color-link-hover: var(--global--color-primary-hover);
 	--footer--font-family: var(--global--font-primary);
 	--footer--font-size: var(--global--font-size-sm);
+	--pagination--color-text: var(--global--color-foreground);
+	--pagination--color-link: var(--global--color-primary);
+	--pagination--color-link-hover: var(--global--color-primary-hover);
+	--pagination--font-family: var(--global--font-secondary);
+	--pagination--font-size: var(--global--font-size-sm);
+	--pagination--font-weight: normal;
 	/* Vendors */
 	--wc--wrapper-width: default;
 	--wc--table--border-color: var(--global--color-border);

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -208,6 +208,12 @@
 	--footer--color-link-hover: var(--global--color-primary-hover);
 	--footer--font-family: var(--global--font-primary);
 	--footer--font-size: var(--global--font-size-sm);
+	--pagination--color-text: var(--global--color-foreground);
+	--pagination--color-link: var(--global--color-primary);
+	--pagination--color-link-hover: var(--global--color-primary-hover);
+	--pagination--font-family: var(--global--font-secondary);
+	--pagination--font-size: var(--global--font-size-sm);
+	--pagination--font-weight: normal;
 	/* Vendors */
 	--wc--wrapper-width: default;
 	--wc--table--border-color: var(--global--color-border);

--- a/varya/assets/sass/components/pagination/_config.scss
+++ b/varya/assets/sass/components/pagination/_config.scss
@@ -2,7 +2,7 @@
 	--pagination--color-text: var(--global--color-foreground);
 	--pagination--color-link: var(--global--color-primary);
 	--pagination--color-link-hover: var(--global--color-primary-hover);
-	--pagination--font-family: var(--global--font-primary);
-	--pagination--font-size: var(--global--font-size-md);
-	--pagination--font-weight: bold;
+	--pagination--font-family: var(--global--font-secondary);
+	--pagination--font-size: var(--global--font-size-sm);
+	--pagination--font-weight: normal;
 }

--- a/varya/assets/sass/components/pagination/_style.scss
+++ b/varya/assets/sass/components/pagination/_style.scss
@@ -81,18 +81,27 @@
 .pagination {
 
 	.nav-links > * {
-		font-family: var(--global--font-primary);
-		font-size: var(--global--font-size-md);
-		font-weight: 600;
-		padding-left: calc(0.66 * var(--global--spacing-unit));
-		padding-right: calc(0.66 * var(--global--spacing-unit));
+		color: var(--pagination--color-text);
+		font-family: var(--pagination--font-family);
+		font-size: var(--pagination--font-size);
+		font-weight: var(--pagination--font-weight);
+		margin-left: calc(0.66 * var(--global--spacing-unit));
+		margin-right: calc(0.66 * var(--global--spacing-unit));
+
+		&.current {
+			border-bottom: 1px solid var(--pagination--color-text);
+		}
 
 		&:first-child {
-			padding-left: 0;
+			margin-left: 0;
+		}
+
+		&a:hover {
+			color: var(--pagination--color-link-hover);
 		}
 
 		&:last-child {
-			padding-right: 0;
+			margin-right: 0;
 		}
 
 		&.next {

--- a/varya/assets/sass/variables.scss
+++ b/varya/assets/sass/variables.scss
@@ -30,6 +30,7 @@
 	@include entry-variables();
 	@include comments-variables();
 	@include footer-variables();
+	@include pagination-variables();
 	/* Vendors */
 	@include woocommerce-variables();
 }

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -927,7 +927,6 @@ input[type=checkbox] + label {
 
 .search-form {
 	display: flex;
-	margin-bottom: var(--global--spacing-vertical);
 }
 
 .search-form > label {
@@ -3326,19 +3325,28 @@ nav a {
 }
 
 .pagination .nav-links > * {
-	font-family: var(--global--font-primary);
-	font-size: var(--global--font-size-md);
-	font-weight: 600;
-	padding-right: calc(0.66 * var(--global--spacing-unit));
-	padding-left: calc(0.66 * var(--global--spacing-unit));
+	color: var(--pagination--color-text);
+	font-family: var(--pagination--font-family);
+	font-size: var(--pagination--font-size);
+	font-weight: var(--pagination--font-weight);
+	margin-right: calc(0.66 * var(--global--spacing-unit));
+	margin-left: calc(0.66 * var(--global--spacing-unit));
+}
+
+.pagination .nav-links > *.current {
+	border-bottom: 1px solid var(--pagination--color-text);
 }
 
 .pagination .nav-links > *:first-child {
-	padding-right: 0;
+	margin-right: 0;
+}
+
+.pagination .nav-links > *a:hover {
+	color: var(--pagination--color-link-hover);
 }
 
 .pagination .nav-links > *:last-child {
-	padding-left: 0;
+	margin-left: 0;
 }
 
 .pagination .nav-links > *.next {

--- a/varya/style.css
+++ b/varya/style.css
@@ -3350,19 +3350,28 @@ nav a {
 }
 
 .pagination .nav-links > * {
-	font-family: var(--global--font-primary);
-	font-size: var(--global--font-size-md);
-	font-weight: 600;
-	padding-left: calc(0.66 * var(--global--spacing-unit));
-	padding-right: calc(0.66 * var(--global--spacing-unit));
+	color: var(--pagination--color-text);
+	font-family: var(--pagination--font-family);
+	font-size: var(--pagination--font-size);
+	font-weight: var(--pagination--font-weight);
+	margin-left: calc(0.66 * var(--global--spacing-unit));
+	margin-right: calc(0.66 * var(--global--spacing-unit));
+}
+
+.pagination .nav-links > *.current {
+	border-bottom: 1px solid var(--pagination--color-text);
 }
 
 .pagination .nav-links > *:first-child {
-	padding-left: 0;
+	margin-left: 0;
+}
+
+.pagination .nav-links > *a:hover {
+	color: var(--pagination--color-link-hover);
 }
 
 .pagination .nav-links > *:last-child {
-	padding-right: 0;
+	margin-right: 0;
 }
 
 .pagination .nav-links > *.next {


### PR DESCRIPTION
Addresses #87.

I discovered there were unused pagination variables. I'm not sure if these are warranted, but made use of them anyways. cc @allancole in case you were thinking of removing these in the audit. 

**Before**
<img width="684" alt="Screen Shot 2020-04-17 at 1 13 00 PM" src="https://user-images.githubusercontent.com/5375500/79595614-2e238a00-80ad-11ea-8168-1879bbebe5c9.png">

**After**
<img width="715" alt="Screen Shot 2020-04-17 at 1 08 45 PM" src="https://user-images.githubusercontent.com/5375500/79595567-16e49c80-80ad-11ea-8a73-aef21593f8e1.png">
