### PR TITLE
Varya: Refine the search block styles

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -378,7 +378,7 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts + .button {
+.wp-block-a8c-blog-posts + .button, .wp-block-search .wp-block-search__button {
 	line-height: var(--button--line-height);
 	color: var(--button--color-text);
 	cursor: pointer;
@@ -392,27 +392,27 @@ object {
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 }
 
-.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-search .wp-block-search__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-search .wp-block-search__button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-search .wp-block-search__button:before {
 	margin-bottom: -calc(.5em * var(--button--line-height) + -.38);
 }
 
-.wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after, .wp-block-search .wp-block-search__button:after {
 	margin-top: -calc(.5em * var(--button--line-height) + -.39);
 }
 
-.wp-block-a8c-blog-posts + .button:active {
+.wp-block-a8c-blog-posts + .button:active, .wp-block-search .wp-block-search__button:active {
 	color: var(--button--color-text-active);
 	background-color: var(--button--color-background-active);
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-search .wp-block-search__button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-search .wp-block-search__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-search .has-focus.wp-block-search__button {
 	color: var(--button--color-text-hover);
 	background-color: var(--button--color-background-hover);
 }
@@ -904,6 +904,30 @@ p.has-background:not(.has-background-background-color) a {
 [style*="background-color"]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
 .wp-block-cover[style*="background-image"] .wp-block-quote .wp-block-quote__citation {
 	color: currentColor;
+}
+
+.wp-block-search {
+	display: flex;
+	max-width: var(--responsive--aligndefault-width);
+}
+
+.wp-block-search .wp-block-search__label {
+	font-weight: normal;
+}
+
+.wp-block-search .wp-block-search__input {
+	border: var(--form--border-width) solid var(--form--border-color);
+	border-radius: var(--form--border-radius);
+	font-family: var(--form--font-family);
+	font-size: var(--form--font-size);
+	line-height: var(--form--line-height);
+	max-width: inherit;
+	margin-right: calc( .66 * var(--global--spacing-horizontal));
+	padding: var(--form--spacing-unit);
+}
+
+.wp-block-search .wp-block-search__input:focus {
+	border-color: var(--form--border-color);
 }
 
 .wp-block-separator,

--- a/varya/assets/sass/blocks/_editor.scss
+++ b/varya/assets/sass/blocks/_editor.scss
@@ -21,6 +21,7 @@
 @import "posts-list/editor";
 @import "pullquote/editor";
 @import "quote/editor";
+@import "search/editor";
 @import "separator/editor";
 @import "slideshow/editor";
 @import "subscription/editor";

--- a/varya/assets/sass/blocks/_style.scss
+++ b/varya/assets/sass/blocks/_style.scss
@@ -24,6 +24,7 @@
 @import "posts-list/style";
 @import "pullquote/style";
 @import "quote/style";
+@import "search/style";
 @import "separator/style";
 @import "slideshow/style";
 @import "spacer/style";

--- a/varya/assets/sass/blocks/search/_editor.scss
+++ b/varya/assets/sass/blocks/search/_editor.scss
@@ -1,0 +1,24 @@
+.wp-block-search {
+    display: flex;
+    max-width: var(--responsive--aligndefault-width);
+    .wp-block-search__label {
+        font-weight: normal;
+    }
+    .wp-block-search__input {
+        border: var(--form--border-width) solid var(--form--border-color);
+        border-radius: var(--form--border-radius);
+        font-family: var(--form--font-family);
+        font-size: var(--form--font-size);
+        line-height: var(--form--line-height);
+        max-width: inherit;
+        margin-right: calc( .66 * var(--global--spacing-horizontal) );
+        padding: var(--form--spacing-unit);
+
+        &:focus {
+            border-color: var(--form--border-color);
+        }
+    }
+    .wp-block-search__button {
+        @extend %button-style;
+    }
+}

--- a/varya/assets/sass/blocks/search/_style.scss
+++ b/varya/assets/sass/blocks/search/_style.scss
@@ -5,7 +5,17 @@
         font-weight: normal;
     }
     .wp-block-search__input {
+        border: var(--form--border-width) solid var(--form--border-color);
+        border-radius: var(--form--border-radius);
+        color: var(--form--color-text);
+        line-height: var(--global--line-height-body);
         max-width: inherit;
         margin-right: calc( .66 * var(--global--spacing-horizontal) );
+        padding: var(--form--spacing-unit);
+
+        &:focus {
+            color: var(--form--color-text);
+            border-color: var(--form--border-color);
+        }
     }
 }

--- a/varya/assets/sass/blocks/search/_style.scss
+++ b/varya/assets/sass/blocks/search/_style.scss
@@ -1,0 +1,11 @@
+.wp-block-search {
+    display: flex;
+    max-width: var(--responsive--aligndefault-width);
+    .wp-block-search__label {
+        font-weight: normal;
+    }
+    .wp-block-search__input {
+        max-width: inherit;
+        margin-right: calc( .66 * var(--global--spacing-horizontal) );
+    }
+}

--- a/varya/assets/sass/components/widgets/_style.scss
+++ b/varya/assets/sass/components/widgets/_style.scss
@@ -2,3 +2,19 @@
 	// Ignore flexbox
 	flex: 0 0 100%;
 }
+
+// Search widget styles
+.search-form {
+	display: flex;
+	margin: auto;
+	max-width: var(--responsive--aligndefault-width);
+
+	> label {
+		display: flex;
+		margin-right: var(--global--spacing-horizontal);
+		width: 100%;
+		.search-field {
+			width: 100%;
+		}
+	}
+}

--- a/varya/assets/sass/elements/_forms.scss
+++ b/varya/assets/sass/elements/_forms.scss
@@ -41,19 +41,3 @@ input[type=checkbox] + label {
 	margin-left: 0.5em;
 	line-height: 1em;
 }
-
-// Search widget styles
-.search-form {
-	display: flex;
-	margin: auto;
-	max-width: var(--responsive--aligndefault-width);
-
-	> label {
-		display: flex;
-		margin-right: var(--global--spacing-horizontal);
-		width: 100%;
-		.search-field {
-			width: 100%;
-		}
-	}
-}

--- a/varya/assets/sass/elements/_forms.scss
+++ b/varya/assets/sass/elements/_forms.scss
@@ -13,12 +13,12 @@ input[type="time"],
 input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
+input.wp-block-search__input,
 textarea {
 	border: var(--form--border-width) solid var(--form--border-color);
 	border-radius: var(--form--border-radius);
 	color: var(--form--color-text);
 	line-height: var(--global--line-height-body);
-
 	padding: var(--form--spacing-unit);
 
 	&:focus {
@@ -42,8 +42,12 @@ input[type=checkbox] + label {
 	line-height: 1em;
 }
 
+// Search widget styles
 .search-form {
 	display: flex;
+	margin: auto;
+	max-width: var(--responsive--aligndefault-width);
+
 	> label {
 		display: flex;
 		margin-right: var(--global--spacing-horizontal);

--- a/varya/assets/sass/elements/_forms.scss
+++ b/varya/assets/sass/elements/_forms.scss
@@ -13,7 +13,6 @@ input[type="time"],
 input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
-input.wp-block-search__input,
 textarea {
 	border: var(--form--border-width) solid var(--form--border-color);
 	border-radius: var(--form--border-radius);

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2173,6 +2173,20 @@ p.has-background {
 	border-color: currentColor;
 }
 
+.wp-block-search {
+	display: flex;
+	max-width: var(--responsive--aligndefault-width);
+}
+
+.wp-block-search .wp-block-search__label {
+	font-weight: normal;
+}
+
+.wp-block-search .wp-block-search__input {
+	max-width: inherit;
+	margin-left: calc( .66 * var(--global--spacing-horizontal));
+}
+
 hr {
 	border-bottom: var(--separator--height) solid var(--separator--border-color);
 	clear: both;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -927,22 +927,6 @@ input[type=checkbox] + label {
 	line-height: 1em;
 }
 
-.search-form {
-	display: flex;
-	margin: auto;
-	max-width: var(--responsive--aligndefault-width);
-}
-
-.search-form > label {
-	display: flex;
-	margin-left: var(--global--spacing-horizontal);
-	width: 100%;
-}
-
-.search-form > label .search-field {
-	width: 100%;
-}
-
 /* Media captions */
 figcaption,
 .wp-caption,
@@ -2183,8 +2167,18 @@ p.has-background {
 }
 
 .wp-block-search .wp-block-search__input {
+	border: var(--form--border-width) solid var(--form--border-color);
+	border-radius: var(--form--border-radius);
+	color: var(--form--color-text);
+	line-height: var(--global--line-height-body);
 	max-width: inherit;
 	margin-left: calc( .66 * var(--global--spacing-horizontal));
+	padding: var(--form--spacing-unit);
+}
+
+.wp-block-search .wp-block-search__input:focus {
+	color: var(--form--color-text);
+	border-color: var(--form--border-color);
 }
 
 hr {
@@ -3669,6 +3663,22 @@ nav a {
 
 .widget-area {
 	flex: 0 0 100%;
+}
+
+.search-form {
+	display: flex;
+	margin: auto;
+	max-width: var(--responsive--aligndefault-width);
+}
+
+.search-form > label {
+	display: flex;
+	margin-left: var(--global--spacing-horizontal);
+	width: 100%;
+}
+
+.search-form > label .search-field {
+	width: 100%;
 }
 
 /* Utilities */

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -883,6 +883,7 @@ input[type="time"],
 input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
+input.wp-block-search__input,
 textarea {
 	border: var(--form--border-width) solid var(--form--border-color);
 	border-radius: var(--form--border-radius);
@@ -906,6 +907,7 @@ input[type="time"]:focus,
 input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
+input.wp-block-search__input:focus,
 textarea:focus {
 	color: var(--form--color-text);
 	border-color: var(--form--border-color);
@@ -927,6 +929,8 @@ input[type=checkbox] + label {
 
 .search-form {
 	display: flex;
+	margin: auto;
+	max-width: var(--responsive--aligndefault-width);
 }
 
 .search-form > label {

--- a/varya/style.css
+++ b/varya/style.css
@@ -891,7 +891,6 @@ input[type="time"],
 input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
-input.wp-block-search__input,
 textarea {
 	border: var(--form--border-width) solid var(--form--border-color);
 	border-radius: var(--form--border-radius);
@@ -915,7 +914,6 @@ input[type="time"]:focus,
 input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
-input.wp-block-search__input:focus,
 textarea:focus {
 	color: var(--form--color-text);
 	border-color: var(--form--border-color);

--- a/varya/style.css
+++ b/varya/style.css
@@ -891,6 +891,7 @@ input[type="time"],
 input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
+input.wp-block-search__input,
 textarea {
 	border: var(--form--border-width) solid var(--form--border-color);
 	border-radius: var(--form--border-radius);
@@ -914,6 +915,7 @@ input[type="time"]:focus,
 input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
+input.wp-block-search__input:focus,
 textarea:focus {
 	color: var(--form--color-text);
 	border-color: var(--form--border-color);
@@ -935,6 +937,8 @@ input[type=checkbox] + label {
 
 .search-form {
 	display: flex;
+	margin: auto;
+	max-width: var(--responsive--aligndefault-width);
 }
 
 .search-form > label {
@@ -2175,6 +2179,20 @@ p.has-background {
 [style*="background-color"] .wp-block-quote,
 .wp-block-cover[style*="background-image"] .wp-block-quote {
 	border-color: currentColor;
+}
+
+.wp-block-search {
+	display: flex;
+	max-width: var(--responsive--aligndefault-width);
+}
+
+.wp-block-search .wp-block-search__label {
+	font-weight: normal;
+}
+
+.wp-block-search .wp-block-search__input {
+	max-width: inherit;
+	margin-right: calc( .66 * var(--global--spacing-horizontal));
 }
 
 hr {

--- a/varya/style.css
+++ b/varya/style.css
@@ -935,22 +935,6 @@ input[type=checkbox] + label {
 	line-height: 1em;
 }
 
-.search-form {
-	display: flex;
-	margin: auto;
-	max-width: var(--responsive--aligndefault-width);
-}
-
-.search-form > label {
-	display: flex;
-	margin-right: var(--global--spacing-horizontal);
-	width: 100%;
-}
-
-.search-form > label .search-field {
-	width: 100%;
-}
-
 /* Media captions */
 figcaption,
 .wp-caption,
@@ -2191,8 +2175,18 @@ p.has-background {
 }
 
 .wp-block-search .wp-block-search__input {
+	border: var(--form--border-width) solid var(--form--border-color);
+	border-radius: var(--form--border-radius);
+	color: var(--form--color-text);
+	line-height: var(--global--line-height-body);
 	max-width: inherit;
 	margin-right: calc( .66 * var(--global--spacing-horizontal));
+	padding: var(--form--spacing-unit);
+}
+
+.wp-block-search .wp-block-search__input:focus {
+	color: var(--form--color-text);
+	border-color: var(--form--border-color);
 }
 
 hr {
@@ -3694,6 +3688,22 @@ nav a {
 
 .widget-area {
 	flex: 0 0 100%;
+}
+
+.search-form {
+	display: flex;
+	margin: auto;
+	max-width: var(--responsive--aligndefault-width);
+}
+
+.search-form > label {
+	display: flex;
+	margin-right: var(--global--spacing-horizontal);
+	width: 100%;
+}
+
+.search-form > label .search-field {
+	width: 100%;
 }
 
 /* Utilities */


### PR DESCRIPTION
Addresses #101.

**Before**
Editor | Front End
------------|------------
<img width="638" alt="Screen Shot 2020-04-17 at 4 06 56 PM" src="https://user-images.githubusercontent.com/5375500/79609884-7fd80e80-80c5-11ea-9b65-a41634f1d73a.png">|<img width="664" alt="Screen Shot 2020-04-17 at 4 07 03 PM" src="https://user-images.githubusercontent.com/5375500/79609902-836b9580-80c5-11ea-86c7-5bbb487f9550.png">


**After**
Editor | Front End
------------|------------
<img width="668" alt="Screen Shot 2020-04-17 at 4 06 03 PM" src="https://user-images.githubusercontent.com/5375500/79609811-6040e600-80c5-11ea-9df6-e140a4262766.png">|<img width="664" alt="Screen Shot 2020-04-17 at 4 00 00 PM" src="https://user-images.githubusercontent.com/5375500/79609733-42738100-80c5-11ea-9ded-7088a786f616.png">

(h/t @allancole for this cool table markdown formatting)

Some considerations:
- Previously there were no search block styles and all the styling took from `elements/_forms.scss`. I felt it would be better to include block styles for this rather than put them in `_forms.scss`, but it makes a handful of styles redundant. I think this still may be the cleanest solution to support both the widget and the search block. 
- I didn't include a new config for the search block, and borrowed the existing `form` variables.