### PR TITLE
Update link underline in the editor

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -105,7 +105,9 @@ body {
 }
 
 a {
+	border-bottom: 1px solid var(--global--color-secondary);
 	color: var(--global--color-primary);
+	text-decoration: none;
 }
 
 a:hover {

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -18,7 +18,9 @@ body {
 
 // Links styles
 a {
+	border-bottom: 1px solid var(--global--color-secondary);
 	color: var(--global--color-primary);
+	text-decoration: none;
 
 	&:hover {
 		color: var(--global--color-primary-hover);


### PR DESCRIPTION
This PR syncs up the link style in the editor with the one used on the front end: 

Before: 

<img width="162" alt="Screen Shot 2020-04-22 at 10 00 21 AM" src="https://user-images.githubusercontent.com/1202812/79991767-a8bf2180-8480-11ea-8120-18fa260b4c95.png">

After: 

<img width="138" alt="Screen Shot 2020-04-22 at 10 00 17 AM" src="https://user-images.githubusercontent.com/1202812/79991773-ab217b80-8480-11ea-803c-342335c36b4c.png">
