### PR TITLE
Update Varya Elevation

### DIFF
--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -67,13 +67,6 @@ body {
 	--global--spacing-measure: unset;
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
-	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -68,10 +68,10 @@ body {
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
 	/* Elevation */
-	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 0px 0px 8px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 2px 2px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -67,6 +67,13 @@ body {
 	--global--spacing-measure: unset;
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
+	/* Elevation */
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -68,12 +68,7 @@ body {
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
 	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
+	--global--elevation: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -68,10 +68,10 @@
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
 	/* Elevation */
-	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 0px 0px 8px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 2px 2px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -67,6 +67,13 @@
 	--global--spacing-measure: unset;
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
+	/* Elevation */
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;
@@ -179,7 +186,6 @@
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
 	--primary-nav--justify-content: center;
-	--primary-nav--box-shadow: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);
 	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -68,12 +68,7 @@
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
 	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
+	--global--elevation: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -67,13 +67,6 @@
 	--global--spacing-measure: unset;
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
-	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;
@@ -186,6 +179,7 @@
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
 	--primary-nav--justify-content: center;
+	--primary-nav--box-shadow: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);
 	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -56,6 +56,14 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--spacing-horizontal: #{2.5 * $baseline-unit}; // 25px
 	--global--spacing-vertical: #{3 * $baseline-unit}; // 30px.
 
+	/* Elevation */
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-none: 0px 0px 0px 0px transparent;
+
 	/* Other */
 	--global--border-radius-sm: #{0.5 * $typescale-root};
 	--global--border-radius-md: #{0.75 * $typescale-root};

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -57,10 +57,10 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--spacing-vertical: #{3 * $baseline-unit}; // 30px.
 
 	/* Elevation */
-	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 0px 0px 8px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 2px 2px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-none: 0px 0px 0px 0px transparent;
 

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -57,12 +57,7 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--spacing-vertical: #{3 * $baseline-unit}; // 30px.
 
 	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
+	--global--elevation: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 
 	/* Other */
 	--global--border-radius-sm: #{0.5 * $typescale-root};

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -56,14 +56,6 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--spacing-horizontal: #{2.5 * $baseline-unit}; // 25px
 	--global--spacing-vertical: #{3 * $baseline-unit}; // 30px.
 
-	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
-
 	/* Other */
 	--global--border-radius-sm: #{0.5 * $typescale-root};
 	--global--border-radius-md: #{0.75 * $typescale-root};

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -67,13 +67,6 @@ body {
 	--global--spacing-measure: unset;
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
-	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -68,10 +68,10 @@ body {
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
 	/* Elevation */
-	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 0px 0px 8px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 2px 2px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -67,6 +67,13 @@ body {
 	--global--spacing-measure: unset;
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
+	/* Elevation */
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -68,12 +68,7 @@ body {
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
 	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
+	--global--elevation: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -68,10 +68,10 @@
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
 	/* Elevation */
-	--global--elevation-1: 0px 0px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 0px 0px 8px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 4px 2px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 2px 2px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
 	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -67,6 +67,13 @@
 	--global--spacing-measure: unset;
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
+	/* Elevation */
+	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
+	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;
@@ -179,7 +186,6 @@
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
 	--primary-nav--justify-content: center;
-	--primary-nav--box-shadow: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);
 	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -68,12 +68,7 @@
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
 	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
+	--global--elevation: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -67,13 +67,6 @@
 	--global--spacing-measure: unset;
 	--global--spacing-horizontal: 25px;
 	--global--spacing-vertical: 30px;
-	/* Elevation */
-	--global--elevation-1: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-2: 1px 1px 4px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-3: 2px 2px 6px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-4: 3px 3px 7px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-5: 4px 4px 8px 0px rgba( 0, 0, 0, 0.2 );
-	--global--elevation-none: 0px 0px 0px 0px transparent;
 	/* Other */
 	--global--border-radius-sm: 9px;
 	--global--border-radius-md: 13.5px;
@@ -186,6 +179,7 @@
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
 	--primary-nav--justify-content: center;
+	--primary-nav--box-shadow: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);
 	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -28,7 +28,6 @@
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
 	--primary-nav--justify-content: center;
-	--primary-nav--box-shadow: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -28,6 +28,7 @@
 	--primary-nav--color-text: var(--global--color-foreground);
 	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
 	--primary-nav--justify-content: center;
+	--primary-nav--box-shadow: 1px 1px 3px 0px rgba( 0, 0, 0, 0.2 );
 
 	--social-nav--color-link: var(--global--color-foreground);
 	--social-nav--color-link-hover: var(--global--color-primary-hover);

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -187,7 +187,7 @@
 			@include media(mobile) {
 				margin: 0;
 				background: var(--global--color-background);
-				box-shadow: var(--primary-nav--box-shadow);
+				box-shadow: var(--global--elevation-1);
 				left: 0;
 				top: 100%;
 				min-width: max-content;

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -187,7 +187,7 @@
 			@include media(mobile) {
 				margin: 0;
 				background: var(--global--color-background);
-				box-shadow: var(--global--elevation-4);
+				box-shadow: var(--global--elevation-1);
 				left: 0;
 				top: 100%;
 				min-width: max-content;

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -187,7 +187,7 @@
 			@include media(mobile) {
 				margin: 0;
 				background: var(--global--color-background);
-				box-shadow: var(--global--elevation-1);
+				box-shadow: var(--global--elevation);
 				left: 0;
 				top: 100%;
 				min-width: max-content;

--- a/varya/assets/sass/components/header/_primary-navigation.scss
+++ b/varya/assets/sass/components/header/_primary-navigation.scss
@@ -187,7 +187,7 @@
 			@include media(mobile) {
 				margin: 0;
 				background: var(--global--color-background);
-				box-shadow: var(--global--elevation-1);
+				box-shadow: var(--primary-nav--box-shadow);
 				left: 0;
 				top: 100%;
 				min-width: max-content;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2866,7 +2866,7 @@ nav a {
 	.main-navigation > div > ul > li > .sub-menu {
 		margin: 0;
 		background: var(--global--color-background);
-		box-shadow: var(--global--elevation-4);
+		box-shadow: var(--global--elevation-1);
 		right: 0;
 		top: 100%;
 		min-width: max-content;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2866,7 +2866,7 @@ nav a {
 	.main-navigation > div > ul > li > .sub-menu {
 		margin: 0;
 		background: var(--global--color-background);
-		box-shadow: var(--global--elevation-1);
+		box-shadow: var(--primary-nav--box-shadow);
 		right: 0;
 		top: 100%;
 		min-width: max-content;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2866,7 +2866,7 @@ nav a {
 	.main-navigation > div > ul > li > .sub-menu {
 		margin: 0;
 		background: var(--global--color-background);
-		box-shadow: var(--global--elevation-1);
+		box-shadow: var(--global--elevation);
 		right: 0;
 		top: 100%;
 		min-width: max-content;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2866,7 +2866,7 @@ nav a {
 	.main-navigation > div > ul > li > .sub-menu {
 		margin: 0;
 		background: var(--global--color-background);
-		box-shadow: var(--primary-nav--box-shadow);
+		box-shadow: var(--global--elevation-1);
 		right: 0;
 		top: 100%;
 		min-width: max-content;

--- a/varya/style.css
+++ b/varya/style.css
@@ -2891,7 +2891,7 @@ nav a {
 	.main-navigation > div > ul > li > .sub-menu {
 		margin: 0;
 		background: var(--global--color-background);
-		box-shadow: var(--global--elevation-1);
+		box-shadow: var(--primary-nav--box-shadow);
 		left: 0;
 		top: 100%;
 		min-width: max-content;

--- a/varya/style.css
+++ b/varya/style.css
@@ -2891,7 +2891,7 @@ nav a {
 	.main-navigation > div > ul > li > .sub-menu {
 		margin: 0;
 		background: var(--global--color-background);
-		box-shadow: var(--global--elevation-1);
+		box-shadow: var(--global--elevation);
 		left: 0;
 		top: 100%;
 		min-width: max-content;

--- a/varya/style.css
+++ b/varya/style.css
@@ -2891,7 +2891,7 @@ nav a {
 	.main-navigation > div > ul > li > .sub-menu {
 		margin: 0;
 		background: var(--global--color-background);
-		box-shadow: var(--global--elevation-4);
+		box-shadow: var(--global--elevation-1);
 		left: 0;
 		top: 100%;
 		min-width: max-content;

--- a/varya/style.css
+++ b/varya/style.css
@@ -2891,7 +2891,7 @@ nav a {
 	.main-navigation > div > ul > li > .sub-menu {
 		margin: 0;
 		background: var(--global--color-background);
-		box-shadow: var(--primary-nav--box-shadow);
+		box-shadow: var(--global--elevation-1);
 		left: 0;
 		top: 100%;
 		min-width: max-content;


### PR DESCRIPTION
The elevation variables in Varya are supposed to progress from least shadow to most shadow. Currently, they do not: 

![Screen Shot 2020-04-22 at 2 20 20 PM](https://user-images.githubusercontent.com/1202812/80018709-71626c00-84a4-11ea-9f3f-f88186103051.png)

This PR adjust those values so there is a more natural progression: 

![Screen Shot 2020-04-22 at 2 20 34 PM](https://user-images.githubusercontent.com/1202812/80018738-7c1d0100-84a4-11ea-9f86-dd44d4b061f5.png)

---

It also adjusts the elevation level of the main navigation so that the shadow is a little more refined. 

Before: 

![Screen Shot 2020-04-22 at 2 19 28 PM](https://user-images.githubusercontent.com/1202812/80018775-8dfea400-84a4-11ea-95c9-6a1be13179c6.png)

After: 

![Screen Shot 2020-04-22 at 2 17 29 PM](https://user-images.githubusercontent.com/1202812/80018788-90f99480-84a4-11ea-93db-b2b6f9ec974f.png)
