### PR TITLE
Varya: Fix pullquote text-alignments.

### DIFF
--- a/varya/assets/sass/blocks/pullquote/_style.scss
+++ b/varya/assets/sass/blocks/pullquote/_style.scss
@@ -39,16 +39,6 @@
 		background: none;
 	}
 
-	&.is-style-default {
-		&.alignleft,
-		&.aligncenter,
-		&.alignright {
-			blockquote > * {
-				text-align: center;
-			}
-		}
-	}
-
     &.is-style-large {
         border-left-color: var(--quote--border-color);
         border-left-style: solid;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2011,10 +2011,6 @@ p.has-background {
 	background: none;
 }
 
-.wp-block-pullquote.is-style-default.alignleft blockquote > *, .wp-block-pullquote.is-style-default.aligncenter blockquote > *, .wp-block-pullquote.is-style-default.alignright blockquote > * {
-	text-align: center;
-}
-
 .wp-block-pullquote.is-style-large {
 	border-right-color: var(--quote--border-color);
 	border-right-style: solid;

--- a/varya/style.css
+++ b/varya/style.css
@@ -2019,10 +2019,6 @@ p.has-background {
 	background: none;
 }
 
-.wp-block-pullquote.is-style-default.alignleft blockquote > *, .wp-block-pullquote.is-style-default.aligncenter blockquote > *, .wp-block-pullquote.is-style-default.alignright blockquote > * {
-	text-align: center;
-}
-
 .wp-block-pullquote.is-style-large {
 	border-left-color: var(--quote--border-color);
 	border-left-style: solid;


### PR DESCRIPTION
Removes the text-align rules on the frontend so that the frontend matches the editor.

Editor|Frontend Before|Frontend After
------------|------------|------------
![image](https://user-images.githubusercontent.com/709581/80139629-bd7ce180-8574-11ea-9eb9-625303e3ef1f.png)|![image](https://user-images.githubusercontent.com/709581/80139572-a938e480-8574-11ea-9d2c-81d0776b6e93.png)|![image](https://user-images.githubusercontent.com/709581/80139524-99210500-8574-11ea-95f2-5ff2feca8812.png)

Fixes: #120 