### PR TITLE
Fix margins on left and right aligned blocks 

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -132,16 +132,6 @@ a {
 	font-size: var(--global--font-size-md);
 }
 
-.wp-block.alignleft {
-	margin: 0;
-	margin-right: var(--global--spacing-horizontal);
-}
-
-.wp-block.alignright {
-	margin: 0;
-	margin-left: var(--global--spacing-horizontal);
-}
-
 div[data-type="core/button"] {
 	display: block;
 }
@@ -1185,6 +1175,17 @@ pre.wp-block-verse {
 [data-block] [data-block] {
 	margin-top: 0;
 	margin-bottom: 0;
+}
+
+/* Block Alignments */
+.alignleft {
+	margin: 0;
+	margin-right: var(--global--spacing-horizontal);
+}
+
+.alignright {
+	margin: 0;
+	margin-left: var(--global--spacing-horizontal);
 }
 
 /**

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -132,8 +132,14 @@ a {
 	font-size: var(--global--font-size-md);
 }
 
-.wp-block.alignright, .wp-block.alignleft {
-	margin: 0 var(--global--spacing-horizontal);
+.wp-block.alignleft {
+	margin: 0;
+	margin-right: var(--global--spacing-horizontal);
+}
+
+.wp-block.alignright {
+	margin: 0;
+	margin-left: var(--global--spacing-horizontal);
 }
 
 div[data-type="core/button"] {

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -132,6 +132,10 @@ a {
 	font-size: var(--global--font-size-md);
 }
 
+.wp-block.alignright, .wp-block.alignleft {
+	margin: 0 var(--global--spacing-horizontal);
+}
+
 div[data-type="core/button"] {
 	display: block;
 }

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -50,16 +50,6 @@ a {
 		font-family: var(--global--font-secondary);
 		font-size: var(--global--font-size-md);
 	}
-
-	&.alignleft {
-		margin: 0;
-		margin-right: var(--global--spacing-horizontal);
-	}
-
-	&.alignright {
-		margin: 0;
-		margin-left: var(--global--spacing-horizontal);
-	}
 }
 
 div[data-type="core/button"] {

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -50,6 +50,10 @@ a {
 		font-family: var(--global--font-secondary);
 		font-size: var(--global--font-size-md);
 	}
+
+	&.alignright, &.alignleft {
+		margin: 0 var(--global--spacing-horizontal);
+	}
 }
 
 div[data-type="core/button"] {

--- a/varya/assets/sass/base/_editor.scss
+++ b/varya/assets/sass/base/_editor.scss
@@ -51,8 +51,14 @@ a {
 		font-size: var(--global--font-size-md);
 	}
 
-	&.alignright, &.alignleft {
-		margin: 0 var(--global--spacing-horizontal);
+	&.alignleft {
+		margin: 0;
+		margin-right: var(--global--spacing-horizontal);
+	}
+
+	&.alignright {
+		margin: 0;
+		margin-left: var(--global--spacing-horizontal);
 	}
 }
 

--- a/varya/assets/sass/blocks/utilities/_editor.scss
+++ b/varya/assets/sass/blocks/utilities/_editor.scss
@@ -156,3 +156,14 @@
 		margin-bottom: 0;
 	}
 }
+
+/* Block Alignments */
+.alignleft {
+	margin: 0;
+	margin-right: var(--global--spacing-horizontal);
+}
+
+.alignright {
+	margin: 0;
+	margin-left: var(--global--spacing-horizontal);
+}


### PR DESCRIPTION
Fixes #104.

**Before**
<img width="679" alt="Screen Shot 2020-04-23 at 6 06 40 PM" src="https://user-images.githubusercontent.com/5375500/80154541-c5954b00-858d-11ea-9b97-a82767608eed.png">

**After**
<img width="691" alt="Screen Shot 2020-04-23 at 6 08 47 PM" src="https://user-images.githubusercontent.com/5375500/80154551-c9c16880-858d-11ea-9cf8-402bfa41e7ce.png">

The issue of alignments is tricky because they are not handled consistently. Sometimes Gutenberg will add `data-align="left"` or a `.alignleft` class, it just depends on the block.