### PR TITLE
Varya: Fix duplicate mini-cart issue in customizer

### DIFF
--- a/varya/assets/js/customize-preview-woocommerce.js
+++ b/varya/assets/js/customize-preview-woocommerce.js
@@ -8,6 +8,7 @@ jQuery( function( $ ) {
 
 	// Remove mini-cart
 	function resetWooMiniCart( container ) {
+
 		var wooMenuContainer = container.siblings( ".woocommerce-menu-container[title|='Shift']" );
 		var wooMenuButton    = container.siblings( "#toggle-cart[title|='Shift']" );
 
@@ -15,6 +16,7 @@ jQuery( function( $ ) {
 		wooMenuButton.remove();
 	}
 
+	// Listen for preview menu refresh
 	$( document ).on( 'customize-preview-menu-refreshed', function( e, params ) {
 		if ( 'primary' === params.wpNavMenuArgs.theme_location ) {
 			resetWooMiniCart( params.newContainer );

--- a/varya/assets/js/customize-preview-woocommerce.js
+++ b/varya/assets/js/customize-preview-woocommerce.js
@@ -7,7 +7,7 @@
 jQuery( function( $ ) {
 
 	// Remove mini-cart
-	function resetWooMenu( container ) {
+	function resetWooMiniCart( container ) {
 		var wooMenuContainer = container.siblings( ".woocommerce-menu-container[title|='Shift']" );
 		var wooMenuButton    = container.siblings( "#toggle-cart[title|='Shift']" );
 
@@ -17,8 +17,7 @@ jQuery( function( $ ) {
 
 	$( document ).on( 'customize-preview-menu-refreshed', function( e, params ) {
 		if ( 'primary' === params.wpNavMenuArgs.theme_location ) {
-			resetWooMenu( params.newContainer );
-			console.log( params );
+			resetWooMiniCart( params.newContainer );
 		}
 	});
 });

--- a/varya/assets/js/woocommerce-customize-preview.js
+++ b/varya/assets/js/woocommerce-customize-preview.js
@@ -1,0 +1,26 @@
+/**
+ * woocommerce-customizer.js.
+ *
+ * Required to prevent duplicate mini-cart instances when updating the menu in the customizer.
+ */
+
+jQuery( function( $ ) {
+
+	// Remove mini-cart
+	function resetWooMenu( container ) {
+		var wooMenuContainer = container.siblings( ".woocommerce-menu-container[title|='Shift']" );
+		var wooMenuButton    = container.siblings( "#toggle-cart[title|='Shift']" );
+
+		wooMenuContainer.remove();
+		wooMenuButton.remove();
+
+		console.log(wooMenuButton);
+	}
+
+	$( document ).on( 'customize-preview-menu-refreshed', function( e, params ) {
+		if ( 'primary' === params.wpNavMenuArgs.theme_location ) {
+			resetWooMenu( params.newContainer );
+			console.log( params );
+		}
+	});
+});

--- a/varya/assets/js/woocommerce-customize-preview.js
+++ b/varya/assets/js/woocommerce-customize-preview.js
@@ -13,8 +13,6 @@ jQuery( function( $ ) {
 
 		wooMenuContainer.remove();
 		wooMenuButton.remove();
-
-		console.log(wooMenuButton);
 	}
 
 	$( document ).on( 'customize-preview-menu-refreshed', function( e, params ) {

--- a/varya/inc/woocommerce.php
+++ b/varya/inc/woocommerce.php
@@ -114,10 +114,10 @@ add_action( 'wp_enqueue_scripts', 'varya_woocommerce_scripts' );
 /**
  * Bind JS handlers to instantly live-preview changes.
  */
-function varya_customize_preview_js() {
-	wp_enqueue_script( 'varya-woocommerce-customize-preview', get_template_directory_uri() . '/assets/js/woocommerce-customize-preview.js', array( 'customize-preview' ), wp_get_theme()->get( 'Version' ), true );
+function varya_woocommerce_customize_preview_js() {
+	wp_enqueue_script( 'customize-preview-woocommerce', get_template_directory_uri() . '/assets/js/customize-preview-woocommerce.js', array( 'customize-preview' ), wp_get_theme()->get( 'Version' ), true );
 }
-add_action( 'customize_preview_init', 'varya_customize_preview_js' );
+add_action( 'customize_preview_init', 'varya_woocommerce_customize_preview_js' );
 
 /**
  * Setup cart link for main menu

--- a/varya/inc/woocommerce.php
+++ b/varya/inc/woocommerce.php
@@ -108,9 +108,16 @@ function varya_woocommerce_scripts() {
 
 	// WooCommerce RTL styles
 	wp_style_add_data( 'varya-woocommerce-style', 'rtl', 'replace' );
-
 }
 add_action( 'wp_enqueue_scripts', 'varya_woocommerce_scripts' );
+
+/**
+ * Bind JS handlers to instantly live-preview changes.
+ */
+function varya_customize_preview_js() {
+	wp_enqueue_script( 'varya-woocommerce-customize-preview', get_template_directory_uri() . '/assets/js/woocommerce-customize-preview.js', array( 'customize-preview' ), wp_get_theme()->get( 'Version' ), true );
+}
+add_action( 'customize_preview_init', 'varya_customize_preview_js' );
 
 /**
  * Setup cart link for main menu
@@ -214,7 +221,7 @@ if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.3', '>=' ) ) {
  * Add WooCommerce mini-cart link to primary menu
  */
 function varya_add_cart_menu( $nav, $args ) {
-	if ( $args->theme_location == 'primary' && ! is_customize_preview() ) {
+	if ( $args->theme_location == 'primary' ) {
 		return sprintf(
 			'%1$s
 			</ul></div>

--- a/varya/inc/woocommerce.php
+++ b/varya/inc/woocommerce.php
@@ -214,7 +214,7 @@ if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.3', '>=' ) ) {
  * Add WooCommerce mini-cart link to primary menu
  */
 function varya_add_cart_menu( $nav, $args ) {
-	if ( $args->theme_location == 'primary' ) {
+	if ( $args->theme_location == 'primary' && ! is_customize_preview() ) {
 		return sprintf(
 			'%1$s
 			</ul></div>


### PR DESCRIPTION
This PR prevents the mini-cart from getting duplicated when the menu gets refreshed in the customizer.

Before|After
------------|------------
![varya-menu-refresh-before](https://user-images.githubusercontent.com/709581/80155834-89afb500-8590-11ea-8d25-04309ed9b1e7.gif)|![varya-menu-refresh-after](https://user-images.githubusercontent.com/709581/80155735-5705bc80-8590-11ea-9ca8-cad417988d0d.gif)

To test, make sure Woo is activated, visit the customizer and make any change to the menu.

Fixes: #84 