### PR TITLE
Varya: Add nav block styles

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -794,6 +794,26 @@ dt {
 	color: currentColor;
 }
 
+.wp-block-navigation .wp-block-navigation__container {
+	background: var(--global--color-background);
+	padding: 0;
+}
+
+.wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__content {
+	font-family: var(--primary-nav--font-family);
+	font-size: var(--primary-nav--font-size);
+	font-weight: var(--primary-nav--font-weight);
+	padding: var(--primary-nav--padding);
+}
+
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover, .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
+	color: var(--primary-nav--color-link-hover);
+}
+
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
+	color: currentColor;
+}
+
 p {
 	line-height: var(--wp--typography--line-height, --global--line-height-body);
 }

--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -806,6 +806,10 @@ dt {
 	padding: var(--primary-nav--padding);
 }
 
+.wp-block-navigation .has-child .wp-block-navigation__container {
+	box-shadow: var(--global--elevation);
+}
+
 .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover, .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
 	color: var(--primary-nav--color-link-hover);
 }

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -163,6 +163,37 @@ body {
 	--utilities--font-size-xl: var(--global--font-size-xl);
 	--utilities--font-size-xxl: var(--global--font-size-xxl);
 	--utilities--font-size-xxxl: var(--global--font-size-xxxl);
+	/* Components */
+	--branding--color-text: var(--global--color-foreground);
+	--branding--color-link: var(--global--color-primary);
+	--branding--color-link-hover: var(--global--color-primary-hover);
+	--branding--title--font-family: var(--global--font-primary);
+	--branding--title--font-size: var(--heading--font-size-h1);
+	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
+	--branding--title--font-weight: 700;
+	--branding--description--font-family: var(--global--font-secondary);
+	--branding--description--font-size: var(--global--font-size-sm);
+	--branding--description--font-family: var(--global--font-secondary);
+	--branding--logo--max-width: 120px;
+	--branding--logo--max-height: 120px;
+	--branding--logo--max-width-mobile: 96px;
+	--branding--logo--max-height-mobile: 96px;
+	--primary-nav--font-family: var(--global--font-secondary);
+	--primary-nav--font-family-mobile: var(--global--font-primary);
+	--primary-nav--font-size: var(--global--font-size-sm);
+	--primary-nav--font-size-mobile: var(--global--font-size-xxl);
+	--primary-nav--font-size-sub-menu-mobile: var(--global--font-size-lg);
+	--primary-nav--font-style: normal;
+	--primary-nav--font-style-sub-menu-mobile: italic;
+	--primary-nav--font-weight: normal;
+	--primary-nav--color-link: var(--global--color-primary);
+	--primary-nav--color-link-hover: var(--global--color-primary-hover);
+	--primary-nav--color-text: var(--global--color-foreground);
+	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
+	--primary-nav--justify-content: center;
+	--social-nav--color-link: var(--global--color-foreground);
+	--social-nav--color-link-hover: var(--global--color-primary-hover);
+	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );
 	/* Vendors */
 	--wc--wrapper-width: default;
 	--wc--table--border-color: var(--global--color-border);

--- a/varya/assets/sass/blocks/_editor.scss
+++ b/varya/assets/sass/blocks/_editor.scss
@@ -18,6 +18,7 @@
 @import "legacy/editor"; // "Blocks" from the legacy WP editor, ie: galleries, .button class, etc.
 @import "list/editor";
 @import "media-text/editor";
+@import "navigation/editor";
 @import "paragraph/editor";
 @import "posts-list/editor";
 @import "pullquote/editor";

--- a/varya/assets/sass/blocks/_style.scss
+++ b/varya/assets/sass/blocks/_style.scss
@@ -20,6 +20,7 @@
 @import "legacy/style"; // "Blocks" from the legacy WP editor, ie: galleries, .button class, etc.
 @import "list/style";
 @import "media-text/style";
+@import "navigation/style";
 @import "paragraph/style";
 @import "posts-list/style";
 @import "pullquote/style";

--- a/varya/assets/sass/blocks/navigation/_editor.scss
+++ b/varya/assets/sass/blocks/navigation/_editor.scss
@@ -12,6 +12,12 @@
             padding: var(--primary-nav--padding);
         }
     }
+
+    .has-child {
+        .wp-block-navigation__container {
+            box-shadow: var(--global--elevation);
+        }
+    }
     
     &:not(.has-text-color){
         .wp-block-navigation-link {

--- a/varya/assets/sass/blocks/navigation/_editor.scss
+++ b/varya/assets/sass/blocks/navigation/_editor.scss
@@ -1,0 +1,29 @@
+.wp-block-navigation {
+    .wp-block-navigation__container {
+        background: var(--global--color-background);
+        padding: 0;
+    }
+
+    .wp-block-navigation-link {
+        .wp-block-navigation-link__content {
+            font-family: var(--primary-nav--font-family);
+            font-size: var(--primary-nav--font-size);
+            font-weight: var(--primary-nav--font-weight);
+            padding: var(--primary-nav--padding);
+        }
+    }
+    
+    &:not(.has-text-color){
+        .wp-block-navigation-link {
+            > a {
+                &:hover, &:focus {
+                    color: var(--primary-nav--color-link-hover);
+                }
+            }
+        }
+
+        .wp-block-navigation-link__content {
+            color: currentColor;
+        }
+    }
+}

--- a/varya/assets/sass/blocks/navigation/_style.scss
+++ b/varya/assets/sass/blocks/navigation/_style.scss
@@ -1,0 +1,81 @@
+.wp-block-navigation {
+    .wp-block-navigation-link {
+        padding: 0;
+
+        .wp-block-navigation-link__content {
+            font-family: var(--primary-nav--font-family);
+            font-size: var(--primary-nav--font-size);
+            font-weight: var(--primary-nav--font-weight);
+            padding: var(--primary-nav--padding);
+        }
+    }
+
+    .wp-block-navigation-link__submenu-icon {
+        padding: 0;
+    }
+
+    // Top level navigation container.
+    > .wp-block-navigation__container {
+        .has-child {
+            .wp-block-navigation-link {
+                display: inherit;
+            }
+
+            .wp-block-navigation__container {
+                border: none;
+                left: 0;
+                margin-left: var(--primary-nav--padding);
+                min-width: max-content;
+                opacity: 0; 
+                padding: 0;
+                position: inherit;
+                top: inherit;
+
+                .wp-block-navigation-link {
+                    .wp-block-navigation-link__content {
+                        display: inline-block;
+                        padding: calc( 0.5 * var(--primary-nav--padding) ) var(--primary-nav--padding);
+                    }
+                }
+
+                .wp-block-navigation-link__submenu-icon {
+                    display: none;
+                }
+            }
+            &:hover, &:focus-within {
+                .wp-block-navigation__container {
+                    display: block;
+                    opacity: 1;
+                    visibility: visible;
+                }
+            }
+        }
+    }
+
+    > .wp-block-navigation__container {
+        > .has-child {
+            > .wp-block-navigation__container {
+                background: var(--global--color-background);
+                box-shadow: var(--global--elevation);
+                margin: 0;
+                padding: 0;
+                position: absolute;
+                top: 100%;
+            }
+        }
+    }
+    
+    &:not(.has-text-color){
+        .wp-block-navigation-link {
+            > a {
+                &:hover, &:focus {
+                    color: var(--primary-nav--color-link-hover);
+                }
+            }
+        }
+
+        .wp-block-navigation-link__content {
+            color: currentColor;
+        }
+    }
+}

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -163,6 +163,37 @@ body {
 	--utilities--font-size-xl: var(--global--font-size-xl);
 	--utilities--font-size-xxl: var(--global--font-size-xxl);
 	--utilities--font-size-xxxl: var(--global--font-size-xxxl);
+	/* Components */
+	--branding--color-text: var(--global--color-foreground);
+	--branding--color-link: var(--global--color-primary);
+	--branding--color-link-hover: var(--global--color-primary-hover);
+	--branding--title--font-family: var(--global--font-primary);
+	--branding--title--font-size: var(--heading--font-size-h1);
+	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
+	--branding--title--font-weight: 700;
+	--branding--description--font-family: var(--global--font-secondary);
+	--branding--description--font-size: var(--global--font-size-sm);
+	--branding--description--font-family: var(--global--font-secondary);
+	--branding--logo--max-width: 120px;
+	--branding--logo--max-height: 120px;
+	--branding--logo--max-width-mobile: 96px;
+	--branding--logo--max-height-mobile: 96px;
+	--primary-nav--font-family: var(--global--font-secondary);
+	--primary-nav--font-family-mobile: var(--global--font-primary);
+	--primary-nav--font-size: var(--global--font-size-sm);
+	--primary-nav--font-size-mobile: var(--global--font-size-xxl);
+	--primary-nav--font-size-sub-menu-mobile: var(--global--font-size-lg);
+	--primary-nav--font-style: normal;
+	--primary-nav--font-style-sub-menu-mobile: italic;
+	--primary-nav--font-weight: normal;
+	--primary-nav--color-link: var(--global--color-primary);
+	--primary-nav--color-link-hover: var(--global--color-primary-hover);
+	--primary-nav--color-text: var(--global--color-foreground);
+	--primary-nav--padding: calc(0.66 * var(--global--spacing-unit) );
+	--primary-nav--justify-content: center;
+	--social-nav--color-link: var(--global--color-foreground);
+	--social-nav--color-link-hover: var(--global--color-primary-hover);
+	--social-nav--padding: calc( 0.5 * var(--primary-nav--padding) );
 	/* Vendors */
 	--wc--wrapper-width: default;
 	--wc--table--border-color: var(--global--color-border);

--- a/varya/assets/sass/variables-editor.scss
+++ b/varya/assets/sass/variables-editor.scss
@@ -25,6 +25,8 @@
 	@include quote-variables();
 	@include separator-variables();
 	@include utilities-variables();
+	/* Components */
+	@include header-variables();
 	/* Vendors */
 	@include woocommerce-variables();
 }

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -1916,6 +1916,68 @@ dd {
 	}
 }
 
+.wp-block-navigation .wp-block-navigation-link {
+	padding: 0;
+}
+
+.wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__content {
+	font-family: var(--primary-nav--font-family);
+	font-size: var(--primary-nav--font-size);
+	font-weight: var(--primary-nav--font-weight);
+	padding: var(--primary-nav--padding);
+}
+
+.wp-block-navigation .wp-block-navigation-link__submenu-icon {
+	padding: 0;
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child .wp-block-navigation-link {
+	display: inherit;
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child .wp-block-navigation__container {
+	border: none;
+	right: 0;
+	margin-right: var(--primary-nav--padding);
+	min-width: max-content;
+	opacity: 0;
+	padding: 0;
+	position: inherit;
+	top: inherit;
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child .wp-block-navigation__container .wp-block-navigation-link .wp-block-navigation-link__content {
+	display: inline-block;
+	padding: calc( 0.5 * var(--primary-nav--padding)) var(--primary-nav--padding);
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child .wp-block-navigation__container .wp-block-navigation-link__submenu-icon {
+	display: none;
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child:hover .wp-block-navigation__container, .wp-block-navigation > .wp-block-navigation__container .has-child:focus-within .wp-block-navigation__container {
+	display: block;
+	opacity: 1;
+	visibility: visible;
+}
+
+.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container {
+	background: var(--global--color-background);
+	box-shadow: var(--global--elevation);
+	margin: 0;
+	padding: 0;
+	position: absolute;
+	top: 100%;
+}
+
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover, .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
+	color: var(--primary-nav--color-link-hover);
+}
+
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
+	color: currentColor;
+}
+
 p {
 	line-height: var(--wp--typography--line-height, --global--line-height-body);
 }

--- a/varya/style.css
+++ b/varya/style.css
@@ -1924,6 +1924,68 @@ dd {
 	}
 }
 
+.wp-block-navigation .wp-block-navigation-link {
+	padding: 0;
+}
+
+.wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__content {
+	font-family: var(--primary-nav--font-family);
+	font-size: var(--primary-nav--font-size);
+	font-weight: var(--primary-nav--font-weight);
+	padding: var(--primary-nav--padding);
+}
+
+.wp-block-navigation .wp-block-navigation-link__submenu-icon {
+	padding: 0;
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child .wp-block-navigation-link {
+	display: inherit;
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child .wp-block-navigation__container {
+	border: none;
+	left: 0;
+	margin-left: var(--primary-nav--padding);
+	min-width: max-content;
+	opacity: 0;
+	padding: 0;
+	position: inherit;
+	top: inherit;
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child .wp-block-navigation__container .wp-block-navigation-link .wp-block-navigation-link__content {
+	display: inline-block;
+	padding: calc( 0.5 * var(--primary-nav--padding)) var(--primary-nav--padding);
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child .wp-block-navigation__container .wp-block-navigation-link__submenu-icon {
+	display: none;
+}
+
+.wp-block-navigation > .wp-block-navigation__container .has-child:hover .wp-block-navigation__container, .wp-block-navigation > .wp-block-navigation__container .has-child:focus-within .wp-block-navigation__container {
+	display: block;
+	opacity: 1;
+	visibility: visible;
+}
+
+.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container {
+	background: var(--global--color-background);
+	box-shadow: var(--global--elevation);
+	margin: 0;
+	padding: 0;
+	position: absolute;
+	top: 100%;
+}
+
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover, .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus {
+	color: var(--primary-nav--color-link-hover);
+}
+
+.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content {
+	color: currentColor;
+}
+
 p {
 	line-height: var(--wp--typography--line-height, --global--line-height-body);
 }


### PR DESCRIPTION
Addresses #116.

This PR adds styles to navigation block to match what we have for the primary navigation.

**Front-end**

Before | After
------- | -------
<img width="836" alt="Screen Shot 2020-04-27 at 6 37 48 PM" src="https://user-images.githubusercontent.com/5375500/80427758-69486900-88b6-11ea-985d-34e37629b03d.png">|<img width="521" alt="Screen Shot 2020-04-27 at 6 37 30 PM" src="https://user-images.githubusercontent.com/5375500/80427772-6ea5b380-88b6-11ea-9b11-0968dd454145.png">

**Editor**
Before | After
------- | -------
<img width="918" alt="Screen Shot 2020-04-27 at 6 39 00 PM" src="https://user-images.githubusercontent.com/5375500/80427818-82e9b080-88b6-11ea-85a3-8fdb53f5d7b8.png">|<img width="747" alt="Screen Shot 2020-04-27 at 6 37 09 PM" src="https://user-images.githubusercontent.com/5375500/80427830-8846fb00-88b6-11ea-81dd-01c23077ff0b.png">

A few considerations:
- It only adds a handful of editor styles as the UI for adding nav items is complex.
- I did not replace the icons around nested menus because they are inline SVG elements generated by the block.
- I did not do anything to specifically address the mobile use case, because supporting the ability to add several fullscreen mobile menus via the nav block would require some additional front-end logic. But we may want to revisit this assumption.