### PR TITLE
Add stripe gradient preset (#92)

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -1236,6 +1236,10 @@ pre.wp-block-verse {
 	background: linear-gradient(to top, #A36265, #FAFBF6);
 }
 
+.has-stripe-gradient-background {
+	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+}
+
 /* Block Alignments */
 .alignleft {
 	margin: 0;

--- a/varya/assets/sass/blocks/utilities/_editor.scss
+++ b/varya/assets/sass/blocks/utilities/_editor.scss
@@ -192,6 +192,10 @@
 	background: linear-gradient(to top, #A36265, #FAFBF6);
 }
 
+.has-stripe-gradient-background {
+	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+}
+
 /* Block Alignments */
 .alignleft {
 	margin: 0;

--- a/varya/assets/sass/blocks/utilities/_style.scss
+++ b/varya/assets/sass/blocks/utilities/_style.scss
@@ -300,3 +300,7 @@
 .has-horizontal-inverted-gradient-background {
 	background: linear-gradient(to top, #A36265, #FAFBF6);
 }
+
+.has-stripe-gradient-background {
+	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+}

--- a/varya/functions.php
+++ b/varya/functions.php
@@ -203,27 +203,32 @@ if ( ! function_exists( 'varya_setup' ) ) :
 				array(
 					'name'     => __( 'Half cream, half brick', 'en' ),
 					'gradient' => 'linear-gradient(to top, #A36265 50%, #FAFBF6 50%)',
-					'slug'     => 'hard-horizontal-inverted'
+					'slug'     => 'hard-horizontal-inverted',
 				),
 				array(
 					'name'     => __( 'Brick to cream diagonal gradient', 'en' ),
 					'gradient' => 'linear-gradient(to bottom right, #A36265, #FAFBF6)',
-					'slug'     => 'diagonal'
+					'slug'     => 'diagonal',
 				),
 				array(
 					'name'     => __( 'Cream to brick diagonal gradient', 'en' ),
 					'gradient' => 'linear-gradient(to top left, #A36265, #FAFBF6)',
-					'slug'     => 'diagonal-inverted'
+					'slug'     => 'diagonal-inverted',
 				),
 				array(
 					'name'     => __( 'Brick to cream gradient', 'en' ),
 					'gradient' => 'linear-gradient(to bottom, #A36265, #FAFBF6)',
-					'slug'     => 'horizontal'
+					'slug'     => 'horizontal',
 				),
 				array(
 					'name'     => __( 'Cream to brick gradient', 'en' ),
 					'gradient' => 'linear-gradient(to top, #A36265, #FAFBF6)',
-					'slug'     => 'horizontal-inverted'
+					'slug'     => 'horizontal-inverted',
+				),
+				array(
+					'name'     => __( 'Brick stripe gradient', 'en' ),
+					'gradient' => 'linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%)',
+					'slug'     => 'stripe',
 				),
 			)
 		);

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2727,6 +2727,10 @@ table th,
 	background: linear-gradient(to top, #A36265, #FAFBF6);
 }
 
+.has-stripe-gradient-background {
+	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+}
+
 /*
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context

--- a/varya/style.css
+++ b/varya/style.css
@@ -2752,6 +2752,10 @@ table th,
 	background: linear-gradient(to top, #A36265, #FAFBF6);
 }
 
+.has-stripe-gradient-background {
+	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+}
+
 /*
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context


### PR DESCRIPTION
Addresses #92, adding a stripe background as a gradient preset. 

We may want to finesse the height of the strip.

<img width="1267" alt="Screen Shot 2020-04-28 at 11 51 19 AM" src="https://user-images.githubusercontent.com/5375500/80509162-04891f00-8947-11ea-997b-7acf6906c55b.png">

Noting that it still encounters this same Gutenberg bug: https://github.com/WordPress/gutenberg/issues/21831.