### PR TITLE
Varya: Use variables in gradient presets

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -1197,39 +1197,39 @@ pre.wp-block-verse {
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, #A36265, #FAFBF6);
+	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265, #FAFBF6);
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-stripe-gradient-background {
-	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+	background: linear-gradient(to bottom, transparent 20%, var(--global--color-secondary) 20%, var(--global--color-secondary) 80%, transparent 80%);
 }
 
 /* Block Alignments */

--- a/varya/assets/sass/blocks/utilities/_editor.scss
+++ b/varya/assets/sass/blocks/utilities/_editor.scss
@@ -168,39 +168,39 @@
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, #A36265, #FAFBF6);
+	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265, #FAFBF6);
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-stripe-gradient-background {
-	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+	background: linear-gradient(to bottom, transparent 20%, var(--global--color-secondary) 20%, var(--global--color-secondary) 80%, transparent 80%);
 }
 
 /* Block Alignments */

--- a/varya/assets/sass/blocks/utilities/_style.scss
+++ b/varya/assets/sass/blocks/utilities/_style.scss
@@ -270,37 +270,37 @@
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, #A36265, #FAFBF6);
+	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265, #FAFBF6);
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-stripe-gradient-background {
-	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+	background: linear-gradient(to bottom, transparent 20%, var(--global--color-secondary) 20%, var(--global--color-secondary) 80%, transparent 80%);
 }

--- a/varya/functions.php
+++ b/varya/functions.php
@@ -182,52 +182,55 @@ if ( ! function_exists( 'varya_setup' ) ) :
 			)
 		);
 
+		$gradient_color_a = 'default' === get_theme_mod( 'custom_colors_active' ) ? '#A36265' : get_theme_mod( 'varya_--global--color-secondary' );
+		$gradient_color_b = 'default' === get_theme_mod( 'custom_colors_active' ) ? '#FAFBF6' : get_theme_mod( 'varya_--global--color-background-light' );
+
 		add_theme_support(
 			'editor-gradient-presets',
 			array(
 				array(
-					'name'     => __( 'Half brick, half cream cutting diagonally', 'en' ),
-					'gradient' => 'linear-gradient(to bottom right, #A36265 49.9%, #FAFBF6 50%)',
-					'slug'     => 'hard-diagonal'
+					'name'     => __( 'Diagonal', 'en' ),
+					'gradient' => 'linear-gradient(to bottom right, ' . $gradient_color_a . ' 49.9%, ' . $gradient_color_b  . ' 50%)',
+					'slug'     => 'hard-diagonal',
 				),
 				array(
-					'name'     => __( 'Half cream, half brick cutting diagonally', 'en' ),
-					'gradient' => 'linear-gradient(to top left, #A36265 49.9%, #FAFBF6 50%)',
-					'slug'     => 'hard-diagonal-inverted'
+					'name'     => __( 'Diagonal inverted', 'en' ),
+					'gradient' => 'linear-gradient(to top left, ' . $gradient_color_a . ' 49.9%, ' . $gradient_color_b . ' 50%)',
+					'slug'     => 'hard-diagonal-inverted',
 				),
 				array(
-					'name'     => __( 'Half brick, half cream', 'en' ),
-					'gradient' => 'linear-gradient(to bottom, #A36265 50%, #FAFBF6 50%)',
-					'slug'     => 'hard-horizontal'
+					'name'     => __( 'Horizontal', 'en' ),
+					'gradient' => 'linear-gradient(to bottom, ' . $gradient_color_a . ' 50%, ' . $gradient_color_b . ' 50%)',
+					'slug'     => 'hard-horizontal',
 				),
 				array(
-					'name'     => __( 'Half cream, half brick', 'en' ),
-					'gradient' => 'linear-gradient(to top, #A36265 50%, #FAFBF6 50%)',
+					'name'     => __( 'Horizontal inverted', 'en' ),
+					'gradient' => 'linear-gradient(to top, ' . $gradient_color_a . ' 50%, ' . $gradient_color_b . ' 50%)',
 					'slug'     => 'hard-horizontal-inverted',
 				),
 				array(
-					'name'     => __( 'Brick to cream diagonal gradient', 'en' ),
-					'gradient' => 'linear-gradient(to bottom right, #A36265, #FAFBF6)',
+					'name'     => __( 'Diagonal gradient', 'en' ),
+					'gradient' => 'linear-gradient(to bottom right, ' . $gradient_color_a . ', ' . $gradient_color_b . ')',
 					'slug'     => 'diagonal',
 				),
 				array(
-					'name'     => __( 'Cream to brick diagonal gradient', 'en' ),
-					'gradient' => 'linear-gradient(to top left, #A36265, #FAFBF6)',
+					'name'     => __( 'Diagonal inverted gradient', 'en' ),
+					'gradient' => 'linear-gradient(to top left, ' . $gradient_color_a . ', ' . $gradient_color_b . ')',
 					'slug'     => 'diagonal-inverted',
 				),
 				array(
-					'name'     => __( 'Brick to cream gradient', 'en' ),
-					'gradient' => 'linear-gradient(to bottom, #A36265, #FAFBF6)',
+					'name'     => __( 'Horizontal gradient', 'en' ),
+					'gradient' => 'linear-gradient(to bottom, ' . $gradient_color_a . ', ' . $gradient_color_b . ')',
 					'slug'     => 'horizontal',
 				),
 				array(
-					'name'     => __( 'Cream to brick gradient', 'en' ),
-					'gradient' => 'linear-gradient(to top, #A36265, #FAFBF6)',
+					'name'     => __( 'Horizontal inverted gradient', 'en' ),
+					'gradient' => 'linear-gradient(to top, ' . $gradient_color_a . ', ' . $gradient_color_b . ')',
 					'slug'     => 'horizontal-inverted',
 				),
 				array(
-					'name'     => __( 'Brick stripe gradient', 'en' ),
-					'gradient' => 'linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%)',
+					'name'     => __( 'Stripe', 'en' ),
+					'gradient' => 'linear-gradient(to bottom, transparent 20%, ' . $gradient_color_a . ' 20%, ' . $gradient_color_a . ' 80%, transparent 80%)',
 					'slug'     => 'stripe',
 				),
 			)

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2696,39 +2696,39 @@ table th,
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom left, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to bottom left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top right, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to top right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom left, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom left, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top right, #A36265, #FAFBF6);
+	background: linear-gradient(to top right, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265, #FAFBF6);
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-stripe-gradient-background {
-	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+	background: linear-gradient(to bottom, transparent 20%, var(--global--color-secondary) 20%, var(--global--color-secondary) 80%, transparent 80%);
 }
 
 /*

--- a/varya/style.css
+++ b/varya/style.css
@@ -2721,39 +2721,39 @@ table th,
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, #A36265 49.9%, #FAFBF6 50%);
+	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, #A36265, #FAFBF6);
+	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265 50%, #FAFBF6 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, #A36265, #FAFBF6);
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, #A36265, #FAFBF6);
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
 }
 
 .has-stripe-gradient-background {
-	background: linear-gradient(to bottom, transparent 20%, #A36265 20%, #A36265 80%, transparent 80%);
+	background: linear-gradient(to bottom, transparent 20%, var(--global--color-secondary) 20%, var(--global--color-secondary) 80%, transparent 80%);
 }
 
 /*


### PR DESCRIPTION
This PR does the following:

- Replaces gradient preset color values with their respective variables.
- Renames the presets to be color agnostic.
- Checks the `custom_colors_active` theme mod to see if custom colors have been set. (Depends on #113)

This should have no impact on the theme visually.  