### PR TITLE
Varya: Add a letter spacing variable for pullquotes

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -837,7 +837,7 @@ p.has-background:not(.has-background-background-color) a {
 	font-family: var(--pullquote--font-family);
 	font-size: var(--pullquote--font-size);
 	font-style: var(--pullquote--font-style);
-	letter-spacing: var(--heading--letter-spacing-h4);
+	letter-spacing: var(--pullquote--letter-spacing);
 	line-height: var(--pullquote--line-height);
 	margin: 0;
 }

--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -139,6 +139,7 @@ body {
 	--pullquote--font-family: var(--global--font-primary);
 	--pullquote--font-size: var(--heading--font-size-h2);
 	--pullquote--font-style: italic;
+	--pullquote--letter-spacing: var(--heading--letter-spacing-h4);
 	--pullquote--line-height: var(--global--line-height-heading);
 	--pullquote--border-width: 0;
 	--pullquote--border-color: transparent;

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -139,6 +139,7 @@
 	--pullquote--font-family: var(--global--font-primary);
 	--pullquote--font-size: var(--heading--font-size-h2);
 	--pullquote--font-style: italic;
+	--pullquote--letter-spacing: var(--heading--letter-spacing-h4);
 	--pullquote--line-height: var(--global--line-height-heading);
 	--pullquote--border-width: 0;
 	--pullquote--border-color: transparent;

--- a/varya/assets/sass/blocks/pullquote/_config.scss
+++ b/varya/assets/sass/blocks/pullquote/_config.scss
@@ -2,6 +2,7 @@
 	--pullquote--font-family: var(--global--font-primary);
 	--pullquote--font-size: var(--heading--font-size-h2);
 	--pullquote--font-style: italic;
+	--pullquote--letter-spacing: var(--heading--letter-spacing-h4);
 	--pullquote--line-height: var(--global--line-height-heading);
 	--pullquote--border-width: 0;
 	--pullquote--border-color: transparent;

--- a/varya/assets/sass/blocks/pullquote/_editor.scss
+++ b/varya/assets/sass/blocks/pullquote/_editor.scss
@@ -14,7 +14,7 @@
 		font-family: var(--pullquote--font-family);
 		font-size: var(--pullquote--font-size);
 		font-style: var(--pullquote--font-style);
-		letter-spacing: var(--heading--letter-spacing-h4);
+		letter-spacing: var(--pullquote--letter-spacing);
 		line-height: var(--pullquote--line-height);
 		margin: 0;
 	}

--- a/varya/assets/sass/blocks/pullquote/_style.scss
+++ b/varya/assets/sass/blocks/pullquote/_style.scss
@@ -14,7 +14,7 @@
 		font-family: var(--pullquote--font-family);
 		font-size: var(--pullquote--font-size);
 		font-style: var(--pullquote--font-style);
-		letter-spacing: var(--heading--letter-spacing-h4);
+		letter-spacing: var(--pullquote--letter-spacing);
 		line-height: var(--pullquote--line-height);
 		margin: 0;
 	}

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -139,6 +139,7 @@ body {
 	--pullquote--font-family: var(--global--font-primary);
 	--pullquote--font-size: var(--heading--font-size-h2);
 	--pullquote--font-style: italic;
+	--pullquote--letter-spacing: var(--heading--letter-spacing-h4);
 	--pullquote--line-height: var(--global--line-height-heading);
 	--pullquote--border-width: 0;
 	--pullquote--border-color: transparent;

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -139,6 +139,7 @@
 	--pullquote--font-family: var(--global--font-primary);
 	--pullquote--font-size: var(--heading--font-size-h2);
 	--pullquote--font-style: italic;
+	--pullquote--letter-spacing: var(--heading--letter-spacing-h4);
 	--pullquote--line-height: var(--global--line-height-heading);
 	--pullquote--border-width: 0;
 	--pullquote--border-color: transparent;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2075,7 +2075,7 @@ p.has-background {
 	font-family: var(--pullquote--font-family);
 	font-size: var(--pullquote--font-size);
 	font-style: var(--pullquote--font-style);
-	letter-spacing: var(--heading--letter-spacing-h4);
+	letter-spacing: var(--pullquote--letter-spacing);
 	line-height: var(--pullquote--line-height);
 	margin: 0;
 }

--- a/varya/style.css
+++ b/varya/style.css
@@ -2083,7 +2083,7 @@ p.has-background {
 	font-family: var(--pullquote--font-family);
 	font-size: var(--pullquote--font-size);
 	font-style: var(--pullquote--font-style);
-	letter-spacing: var(--heading--letter-spacing-h4);
+	letter-spacing: var(--pullquote--letter-spacing);
 	line-height: var(--pullquote--line-height);
 	margin: 0;
 }


### PR DESCRIPTION
This PR creates a pullquote-specific variable to set the letter spacing.

This CSS property is currently tied to the H4 letter spacing, but I think a child theme designer should have control if they don't want those values to be the same. 