### PR TITLE
Varya: Update style.css header

### DIFF
--- a/varya/assets/sass/child-theme/style-child-theme.scss
+++ b/varya/assets/sass/child-theme/style-child-theme.scss
@@ -4,7 +4,9 @@ Theme URI: https://github.com/Automattic/theme-workspace/varya
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
-Requires at least: WordPress 4.9.6
+Requires at least: 4.9.6
+Tested up to: 5.4.1
+Requires PHP: 7.3
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/varya/assets/sass/style.scss
+++ b/varya/assets/sass/style.scss
@@ -1,10 +1,12 @@
 /*
 Theme Name: Varya
 Theme URI: https://github.com/Automattic/theme-workspace/varya
-Author: Dotorg Themes
-Author URI: https://wordpress.org/
+Author: Automattic
+Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
-Requires at least: WordPress 4.9.6
+Requires at least: 4.9.6
+Tested up to: 5.4.1
+Requires PHP: 7.3
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/varya/readme.txt
+++ b/varya/readme.txt
@@ -1,8 +1,8 @@
 === Varya ===
 Contributors: Automattic
 Requires at least: 5.0
-Tested up to: 5.2
-Requires PHP: 5.6
+Tested up to: 5.4.1
+Requires PHP: 7.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -1,10 +1,12 @@
 /*
 Theme Name: Varya
 Theme URI: https://github.com/Automattic/theme-workspace/varya
-Author: Dotorg Themes
-Author URI: https://wordpress.org/
+Author: Automattic
+Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
-Requires at least: WordPress 4.9.6
+Requires at least: 4.9.6
+Tested up to: 5.4.1
+Requires PHP: 7.3
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/varya/style.css
+++ b/varya/style.css
@@ -1,10 +1,12 @@
 /*
 Theme Name: Varya
 Theme URI: https://github.com/Automattic/theme-workspace/varya
-Author: Dotorg Themes
-Author URI: https://wordpress.org/
+Author: Automattic
+Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
-Requires at least: WordPress 4.9.6
+Requires at least: 4.9.6
+Tested up to: 5.4.1
+Requires PHP: 7.3
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: LICENSE


### PR DESCRIPTION
Cleans up a few things in the `style.css` header: 

- Changes the author to Automattic
- Removes the "WordPress" text from the `Requires at least` entry.
- Adds the `Tested up to` and `Requires PHP` entires, as per [new requirements](https://make.wordpress.org/themes/2020/05/14/new-required-header-fields-for-style-css/). For the PHP version, I used the [earliest version supported by WP](https://wordpress.org/about/requirements/). 