### PR TITLE
Varya: Use correct font styles for the nav block.

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -787,10 +787,13 @@ dt {
 }
 
 .wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__content {
+	padding: var(--primary-nav--padding);
+}
+
+.wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__label {
 	font-family: var(--primary-nav--font-family);
 	font-size: var(--primary-nav--font-size);
 	font-weight: var(--primary-nav--font-weight);
-	padding: var(--primary-nav--padding);
 }
 
 .wp-block-navigation .has-child .wp-block-navigation__container {

--- a/varya/assets/sass/blocks/navigation/_editor.scss
+++ b/varya/assets/sass/blocks/navigation/_editor.scss
@@ -6,10 +6,13 @@
 
     .wp-block-navigation-link {
         .wp-block-navigation-link__content {
+            padding: var(--primary-nav--padding);
+        }
+
+        .wp-block-navigation-link__label {
             font-family: var(--primary-nav--font-family);
             font-size: var(--primary-nav--font-size);
             font-weight: var(--primary-nav--font-weight);
-            padding: var(--primary-nav--padding);
         }
     }
 

--- a/varya/assets/sass/blocks/navigation/_style.scss
+++ b/varya/assets/sass/blocks/navigation/_style.scss
@@ -3,10 +3,13 @@
         padding: 0;
 
         .wp-block-navigation-link__content {
+            padding: var(--primary-nav--padding);
+        }
+
+        .wp-block-navigation-link__label {
             font-family: var(--primary-nav--font-family);
             font-size: var(--primary-nav--font-size);
             font-weight: var(--primary-nav--font-weight);
-            padding: var(--primary-nav--padding);
         }
     }
 

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -1888,10 +1888,13 @@ dd {
 }
 
 .wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__content {
+	padding: var(--primary-nav--padding);
+}
+
+.wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__label {
 	font-family: var(--primary-nav--font-family);
 	font-size: var(--primary-nav--font-size);
 	font-weight: var(--primary-nav--font-weight);
-	padding: var(--primary-nav--padding);
 }
 
 .wp-block-navigation .wp-block-navigation-link__submenu-icon {

--- a/varya/style.css
+++ b/varya/style.css
@@ -1896,10 +1896,13 @@ dd {
 }
 
 .wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__content {
+	padding: var(--primary-nav--padding);
+}
+
+.wp-block-navigation .wp-block-navigation-link .wp-block-navigation-link__label {
 	font-family: var(--primary-nav--font-family);
 	font-size: var(--primary-nav--font-size);
 	font-weight: var(--primary-nav--font-weight);
-	padding: var(--primary-nav--padding);
 }
 
 .wp-block-navigation .wp-block-navigation-link__submenu-icon {


### PR DESCRIPTION
I think the markup changed in the nav block — our font styles don't seem to work as of Gutenberg 8.1.0. This PR gets them working again. 

Before: 

<img width="454" alt="Screen Shot 2020-05-20 at 11 11 49 AM" src="https://user-images.githubusercontent.com/1202812/82463606-09934700-9a8b-11ea-9ee3-370160bd4611.png">

After: 

<img width="430" alt="Screen Shot 2020-05-20 at 11 11 58 AM" src="https://user-images.githubusercontent.com/1202812/82463617-0d26ce00-9a8b-11ea-8d37-5e0cf9426498.png">
