### PR TITLE
Varya: Fix quote padding and borders

### DIFF
--- a/varya/assets/sass/blocks/quote/_style.scss
+++ b/varya/assets/sass/blocks/quote/_style.scss
@@ -1,6 +1,5 @@
 .wp-block-quote {
-	border-left-color: var(--quote--border-color);
-	border-left-width: var(--quote--border-width);
+	border-left: var(--quote--border-width) solid var(--quote--border-color);
 	margin: var(--global--spacing-vertical) 0;
 	padding-left: var(--global--spacing-horizontal);
 
@@ -42,29 +41,36 @@
 	 * Block Options
 	 */
 	&.has-text-align-right {
+		border-left: none;
 		border-right: var(--quote--border-width) solid var(--quote--border-color);
+		padding-left: 0;
+		padding-right: var(--global--spacing-horizontal);
+	}
+	
+	&.has-text-align-center {
+		border: none;
 	}
 
 	&.is-style-large,
 	&.is-large {
-		border-left: var(--quote--border-width) solid var(--quote--border-color);
-		padding-left: var(--global--spacing-horizontal);
 		/* Resetting margins to match _block-container.scss */
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
+		padding-left: var(--global--spacing-horizontal);
+
+		&.has-text-align-right {
+			padding-left: 0;
+			padding-right: var(--global--spacing-horizontal);
+		}
+		
+		&.has-text-align-center {
+			padding: 0 var(--global--spacing-horizontal);
+		}
 
 		p {
 			font-size: var(--quote--font-size-large);
 			font-style: var(--quote--font-style-large);
 			line-height: var(--quote--line-height-large);
-		}
-
-		&.has-text-align-right {
-			border-left: none;
-		}
-
-		&.has-text-align-center {
-			border: none;
 		}
 
 		.wp-block-quote__citation,

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -2109,8 +2109,7 @@ p.has-background {
 }
 
 .wp-block-quote {
-	border-right-color: var(--quote--border-color);
-	border-right-width: var(--quote--border-width);
+	border-right: var(--quote--border-width) solid var(--quote--border-color);
 	margin: var(--global--spacing-vertical) 0;
 	padding-right: var(--global--spacing-horizontal);
 	/**
@@ -2167,29 +2166,36 @@ p.has-background {
 }
 
 .wp-block-quote.has-text-align-right {
+	border-right: none;
 	border-left: var(--quote--border-width) solid var(--quote--border-color);
+	padding-right: 0;
+	padding-left: var(--global--spacing-horizontal);
+}
+
+.wp-block-quote.has-text-align-center {
+	border: none;
 }
 
 .wp-block-quote.is-style-large, .wp-block-quote.is-large {
-	border-right: var(--quote--border-width) solid var(--quote--border-color);
-	padding-right: var(--global--spacing-horizontal);
 	/* Resetting margins to match _block-container.scss */
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
+	padding-right: var(--global--spacing-horizontal);
+}
+
+.wp-block-quote.is-style-large.has-text-align-right, .wp-block-quote.is-large.has-text-align-right {
+	padding-right: 0;
+	padding-left: var(--global--spacing-horizontal);
+}
+
+.wp-block-quote.is-style-large.has-text-align-center, .wp-block-quote.is-large.has-text-align-center {
+	padding: 0 var(--global--spacing-horizontal);
 }
 
 .wp-block-quote.is-style-large p, .wp-block-quote.is-large p {
 	font-size: var(--quote--font-size-large);
 	font-style: var(--quote--font-style-large);
 	line-height: var(--quote--line-height-large);
-}
-
-.wp-block-quote.is-style-large.has-text-align-right, .wp-block-quote.is-large.has-text-align-right {
-	border-right: none;
-}
-
-.wp-block-quote.is-style-large.has-text-align-center, .wp-block-quote.is-large.has-text-align-center {
-	border: none;
 }
 
 .wp-block-quote.is-style-large .wp-block-quote__citation,

--- a/varya/style.css
+++ b/varya/style.css
@@ -2117,8 +2117,7 @@ p.has-background {
 }
 
 .wp-block-quote {
-	border-left-color: var(--quote--border-color);
-	border-left-width: var(--quote--border-width);
+	border-left: var(--quote--border-width) solid var(--quote--border-color);
 	margin: var(--global--spacing-vertical) 0;
 	padding-left: var(--global--spacing-horizontal);
 	/**
@@ -2175,29 +2174,36 @@ p.has-background {
 }
 
 .wp-block-quote.has-text-align-right {
+	border-left: none;
 	border-right: var(--quote--border-width) solid var(--quote--border-color);
+	padding-left: 0;
+	padding-right: var(--global--spacing-horizontal);
+}
+
+.wp-block-quote.has-text-align-center {
+	border: none;
 }
 
 .wp-block-quote.is-style-large, .wp-block-quote.is-large {
-	border-left: var(--quote--border-width) solid var(--quote--border-color);
-	padding-left: var(--global--spacing-horizontal);
 	/* Resetting margins to match _block-container.scss */
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
+	padding-left: var(--global--spacing-horizontal);
+}
+
+.wp-block-quote.is-style-large.has-text-align-right, .wp-block-quote.is-large.has-text-align-right {
+	padding-left: 0;
+	padding-right: var(--global--spacing-horizontal);
+}
+
+.wp-block-quote.is-style-large.has-text-align-center, .wp-block-quote.is-large.has-text-align-center {
+	padding: 0 var(--global--spacing-horizontal);
 }
 
 .wp-block-quote.is-style-large p, .wp-block-quote.is-large p {
 	font-size: var(--quote--font-size-large);
 	font-style: var(--quote--font-style-large);
 	line-height: var(--quote--line-height-large);
-}
-
-.wp-block-quote.is-style-large.has-text-align-right, .wp-block-quote.is-large.has-text-align-right {
-	border-left: none;
-}
-
-.wp-block-quote.is-style-large.has-text-align-center, .wp-block-quote.is-large.has-text-align-center {
-	border: none;
 }
 
 .wp-block-quote.is-style-large .wp-block-quote__citation,


### PR DESCRIPTION
This PR addresses a bug that arose recently in how borders and padding was applied on quote blocks. The bug affected the front-end only.

**Before**
<img width="683" alt="Screen Shot 2020-05-20 at 3 17 26 PM" src="https://user-images.githubusercontent.com/5375500/82488018-3a847380-9aad-11ea-8919-5077b3067fd7.png">

**After**
<img width="689" alt="Screen Shot 2020-05-20 at 3 16 38 PM" src="https://user-images.githubusercontent.com/5375500/82488022-3ce6cd80-9aad-11ea-9efd-34c382db49e7.png">
