### PR TITLE
Add max-width rules for featured images.

### DIFF
--- a/varya/assets/sass/components/entry/_post-thumbnail.scss
+++ b/varya/assets/sass/components/entry/_post-thumbnail.scss
@@ -3,7 +3,12 @@
  */
 
 .post-thumbnail {
+	@extend %responsive-aligndefault-width;
 	text-align: center;
+
+	.singular & {
+		@extend %responsive-alignfull-width;
+	}
 
 	.post-thumbnail-inner {
 		display: block;

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -140,7 +140,7 @@ Included in theme screenshot.
  * Extends
  */
 .default-max-width, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce),
-.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .navigation {
+.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .post-thumbnail, .navigation {
 	max-width: var(--responsive--aligndefault-width);
 	margin-right: auto;
 	margin-left: auto;
@@ -152,7 +152,7 @@ Included in theme screenshot.
 	margin-left: auto;
 }
 
-.full-max-width, .entry-content > .alignfull {
+.full-max-width, .entry-content > .alignfull, .singular .post-thumbnail {
 	max-width: var(--responsive--alignfull-width);
 	margin-right: auto;
 	margin-left: auto;

--- a/varya/style.css
+++ b/varya/style.css
@@ -140,7 +140,7 @@ Included in theme screenshot.
  * Extends
  */
 .default-max-width, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce),
-.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .navigation {
+.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .post-thumbnail, .navigation {
 	max-width: var(--responsive--aligndefault-width);
 	margin-left: auto;
 	margin-right: auto;
@@ -152,7 +152,7 @@ Included in theme screenshot.
 	margin-right: auto;
 }
 
-.full-max-width, .entry-content > .alignfull {
+.full-max-width, .entry-content > .alignfull, .singular .post-thumbnail {
 	max-width: var(--responsive--alignfull-width);
 	margin-left: auto;
 	margin-right: auto;


### PR DESCRIPTION
Closes #136. Makes featured images full-width on single pages, but standard width everywhere else. 

Single page:

![dotorgthemes test__p=2450](https://user-images.githubusercontent.com/1202812/82488358-c0082380-9aad-11ea-9ece-6af0f9b5522b.png)

Archive page: 

![dotorgthemes test_](https://user-images.githubusercontent.com/1202812/82488367-c4344100-9aad-11ea-992b-7bd147d2f698.png)
