### PR TITLE
Varya: adjust comment form field CSS

### DIFF
--- a/varya/assets/sass/components/comments/_comment-form.scss
+++ b/varya/assets/sass/components/comments/_comment-form.scss
@@ -29,6 +29,9 @@
 .comment-form {
 	display: flex;
 	flex-wrap: wrap;
+	> * {
+		flex-basis: 100%;
+	}
 
 	.comment-notes {
 		font-size: var(--global--font-size-sm);
@@ -41,16 +44,13 @@
 
 	.comment-form-author,
 	.comment-form-email {
+		flex-basis: 0;
 		flex-grow: 1;
 	}
 
 	.comment-form-cookies-consent > label, 
 	.comment-notes {
 		font-size: var(--global--font-size-xs);
-	}
-
-	.form-submit {
-		flex-basis: 100%;
 	}
 }
 

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -3736,6 +3736,10 @@ nav a {
 	flex-wrap: wrap;
 }
 
+.comment-form > * {
+	flex-basis: 100%;
+}
+
 .comment-form .comment-notes {
 	font-size: var(--global--font-size-sm);
 }
@@ -3747,16 +3751,13 @@ nav a {
 
 .comment-form .comment-form-author,
 .comment-form .comment-form-email {
+	flex-basis: 0;
 	flex-grow: 1;
 }
 
 .comment-form .comment-form-cookies-consent > label,
 .comment-form .comment-notes {
 	font-size: var(--global--font-size-xs);
-}
-
-.comment-form .form-submit {
-	flex-basis: 100%;
 }
 
 .comment-form > p {

--- a/varya/style.css
+++ b/varya/style.css
@@ -3761,6 +3761,10 @@ nav a {
 	flex-wrap: wrap;
 }
 
+.comment-form > * {
+	flex-basis: 100%;
+}
+
 .comment-form .comment-notes {
 	font-size: var(--global--font-size-sm);
 }
@@ -3772,16 +3776,13 @@ nav a {
 
 .comment-form .comment-form-author,
 .comment-form .comment-form-email {
+	flex-basis: 0;
 	flex-grow: 1;
 }
 
 .comment-form .comment-form-cookies-consent > label,
 .comment-form .comment-notes {
 	font-size: var(--global--font-size-xs);
-}
-
-.comment-form .form-submit {
-	flex-basis: 100%;
 }
 
 .comment-form > p {


### PR DESCRIPTION
This PR makes a minor CSS adjustment so that form fields appear more predictably.

Related to #155.

There should be no visual impact. 