### PR TITLE
Varya: Remove flex-basis rule from woocommerce comments

### DIFF
--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -1141,10 +1141,6 @@ body[class*="woocommerce"] #page #reviews h2 small a {
 	color: currentColor;
 }
 
-body[class*="woocommerce"] #page #reviews .comment-form > p {
-	flex-basis: 100%;
-}
-
 body[class*="woocommerce"] #page #reviews .comment-form .stars a {
 	border-bottom: none;
 }

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -1141,10 +1141,6 @@ body[class*="woocommerce"] #page #reviews h2 small a {
 	color: currentColor;
 }
 
-body[class*="woocommerce"] #page #reviews .comment-form > p {
-	flex-basis: 100%;
-}
-
 body[class*="woocommerce"] #page #reviews .comment-form .stars a {
 	border-bottom: none;
 }

--- a/varya/assets/sass/vendors/woocommerce/components/_reviews.scss
+++ b/varya/assets/sass/vendors/woocommerce/components/_reviews.scss
@@ -24,9 +24,6 @@ body[class*="woocommerce"] #page { // adding #content here to override default w
 		}
 
 		.comment-form {
-			> p {
-				flex-basis: 100%;
-			}
 
 			.stars a {
 				border-bottom: none;


### PR DESCRIPTION
Assuming #156 makes it in, the `flex-basis` rule added in #155 will be unnecessary. This PR removes that rule. 

To verify, view a WooCommerce comments form and verify that the "Your Rating" stars are showing up on their own line, as they do in the "After" screenshot in #155. 