### PR TITLE
Varya: Add mobile full-width rules

### DIFF
--- a/varya/assets/css/style-editor.css
+++ b/varya/assets/css/style-editor.css
@@ -81,9 +81,19 @@
 }
 
 .full-max-width {
-	max-width: var(--responsive--alignfull-width);
-	margin-left: auto;
+	max-width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	margin-left: calc(-1 * var(--global--spacing-horizontal));
 	margin-right: auto;
+}
+
+@media only screen and (min-width: 482px) {
+	.full-max-width {
+		max-width: var(--responsive--alignfull-width);
+		width: auto;
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
 /**

--- a/varya/assets/css/style-woocommerce-rtl.css
+++ b/varya/assets/css/style-woocommerce-rtl.css
@@ -78,9 +78,19 @@
 }
 
 .full-max-width {
-	max-width: var(--responsive--alignfull-width);
-	margin-right: auto;
+	max-width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	margin-right: calc(-1 * var(--global--spacing-horizontal));
 	margin-left: auto;
+}
+
+@media only screen and (min-width: 482px) {
+	.full-max-width {
+		max-width: var(--responsive--alignfull-width);
+		width: auto;
+		margin-right: auto;
+		margin-left: auto;
+	}
 }
 
 body[class*="woocommerce"] .entry-content > .woocommerce {

--- a/varya/assets/css/style-woocommerce.css
+++ b/varya/assets/css/style-woocommerce.css
@@ -78,9 +78,19 @@
 }
 
 .full-max-width {
-	max-width: var(--responsive--alignfull-width);
-	margin-left: auto;
+	max-width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	margin-left: calc(-1 * var(--global--spacing-horizontal));
 	margin-right: auto;
+}
+
+@media only screen and (min-width: 482px) {
+	.full-max-width {
+		max-width: var(--responsive--alignfull-width);
+		width: auto;
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
 body[class*="woocommerce"] .entry-content > .woocommerce {

--- a/varya/assets/sass/blocks/utilities/_style.scss
+++ b/varya/assets/sass/blocks/utilities/_style.scss
@@ -85,7 +85,8 @@
 }
 
 .entry-content > .alignfull {
-	@extend %responsive-alignfull-width;
+	@extend %responsive-alignfull-width-mobile;
+	@extend %responsive-alignfull-width;	
 }
 
 .entry-content > .alignfull [class*="inner-container"] > .alignwide {

--- a/varya/assets/sass/components/entry/_post-thumbnail.scss
+++ b/varya/assets/sass/components/entry/_post-thumbnail.scss
@@ -7,6 +7,7 @@
 	text-align: center;
 
 	.singular & {
+		@extend %responsive-alignfull-width-mobile;
 		@extend %responsive-alignfull-width;
 	}
 

--- a/varya/assets/sass/structure/_responsive-logic.scss
+++ b/varya/assets/sass/structure/_responsive-logic.scss
@@ -151,10 +151,20 @@ $breakpoint_xxl: 1024px;
 	margin-right: auto;
 }
 
-%responsive-alignfull-width {
-	max-width: var(--responsive--alignfull-width);
-	margin-left: auto;
+%responsive-alignfull-width-mobile {
+	max-width: calc(100% + (2 * var(--global--spacing-horizontal));
+	width: calc(100% + (2 * var(--global--spacing-horizontal));
+	margin-left: calc(-1 * var(--global--spacing-horizontal));
 	margin-right: auto;
+}
+
+@include media(mobile) {
+	%responsive-alignfull-width {
+		max-width: var(--responsive--alignfull-width);
+		width: auto;
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
 %responsive-alignwide-width-nested {
@@ -216,5 +226,6 @@ $breakpoint_xxl: 1024px;
 }
 
 .full-max-width {
+	@extend %responsive-alignfull-width-mobile;
 	@extend %responsive-alignfull-width;
 }

--- a/varya/assets/sass/structure/_vertical-margins.scss
+++ b/varya/assets/sass/structure/_vertical-margins.scss
@@ -80,6 +80,7 @@
  * Set the full maximum responsive content-width
  */
 .full-max-width {
+	@extend %responsive-alignfull-width-mobile;
 	@extend %responsive-alignfull-width;
 }
 

--- a/varya/style-rtl.css
+++ b/varya/style-rtl.css
@@ -153,9 +153,19 @@ Included in theme screenshot.
 }
 
 .full-max-width, .entry-content > .alignfull, .singular .post-thumbnail {
-	max-width: var(--responsive--alignfull-width);
-	margin-right: auto;
+	max-width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	margin-right: calc(-1 * var(--global--spacing-horizontal));
 	margin-left: auto;
+}
+
+@media only screen and (min-width: 482px) {
+	.full-max-width, .entry-content > .alignfull, .singular .post-thumbnail {
+		max-width: var(--responsive--alignfull-width);
+		width: auto;
+		margin-right: auto;
+		margin-left: auto;
+	}
 }
 
 .entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide {

--- a/varya/style.css
+++ b/varya/style.css
@@ -153,9 +153,19 @@ Included in theme screenshot.
 }
 
 .full-max-width, .entry-content > .alignfull, .singular .post-thumbnail {
-	max-width: var(--responsive--alignfull-width);
-	margin-left: auto;
+	max-width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	width: calc(100% + (2 * var(--global--spacing-horizontal)));
+	margin-left: calc(-1 * var(--global--spacing-horizontal));
 	margin-right: auto;
+}
+
+@media only screen and (min-width: 482px) {
+	.full-max-width, .entry-content > .alignfull, .singular .post-thumbnail {
+		max-width: var(--responsive--alignfull-width);
+		width: auto;
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
 .entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide {


### PR DESCRIPTION
I noticed that full-width blocks were not appearing full-width on mobile. This is because of a general padding rule around the entire page. 

This PR creates a new `%responsive-alignfull-width-mobile` extend rule, and adds that to the places where we were previously extending `%responsive-alignfull-width`. This follows the approach used for mobile rules in `%responsive-alignleft` and `%responsive-alignright`.

The new rule adds a negative margin and increases the width of the element so that it's truly full screen on small screens. 

Before|After
---|---
![dotorgthemes test__p=19](https://user-images.githubusercontent.com/1202812/83028258-28e82200-9fff-11ea-9a29-430dfabc328d.png)|![dotorgthemes test__p=19 (1)](https://user-images.githubusercontent.com/1202812/83028271-2be31280-9fff-11ea-9cc4-5ca32d9d22fb.png)


