### PR TITLE
Varya: Update xxxl text size

### DIFF
--- a/varya/assets/css/variables-editor.css
+++ b/varya/assets/css/variables-editor.css
@@ -38,7 +38,7 @@ body {
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;
 	--global--font-size-xxl: 32px;
-	--global--font-size-xxxl: 64px;
+	--global--font-size-xxxl: 48px;
 	/* Line Height */
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
@@ -169,8 +169,8 @@ body {
 	--branding--color-link: var(--global--color-primary);
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
-	--branding--title--font-size: var(--heading--font-size-h1);
-	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
+	--branding--title--font-size: calc( 1.25 * var(--heading--font-size-h1) );
+	--branding--title--font-size-mobile: var(--heading--font-size-h1);
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);

--- a/varya/assets/css/variables.css
+++ b/varya/assets/css/variables.css
@@ -38,7 +38,7 @@
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;
 	--global--font-size-xxl: 32px;
-	--global--font-size-xxxl: 64px;
+	--global--font-size-xxxl: 48px;
 	/* Line Height */
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
@@ -169,8 +169,8 @@
 	--branding--color-link: var(--global--color-primary);
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
-	--branding--title--font-size: var(--heading--font-size-h1);
-	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
+	--branding--title--font-size: calc( 1.25 * var(--heading--font-size-h1) );
+	--branding--title--font-size-mobile: var(--heading--font-size-h1);
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);

--- a/varya/assets/sass/abstracts/_config.scss
+++ b/varya/assets/sass/abstracts/_config.scss
@@ -23,7 +23,7 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;
 	--global--font-size-xxl: 32px;
-	--global--font-size-xxxl: 64px;
+	--global--font-size-xxxl: 48px;
 
 	/* Line Height */
 	--global--line-height-base: #{$typescale-base / ( $typescale-base * 0 + 1 )};

--- a/varya/assets/sass/child-theme/variables-editor.css
+++ b/varya/assets/sass/child-theme/variables-editor.css
@@ -38,7 +38,7 @@ body {
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;
 	--global--font-size-xxl: 32px;
-	--global--font-size-xxxl: 64px;
+	--global--font-size-xxxl: 48px;
 	/* Line Height */
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
@@ -169,8 +169,8 @@ body {
 	--branding--color-link: var(--global--color-primary);
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
-	--branding--title--font-size: var(--heading--font-size-h1);
-	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
+	--branding--title--font-size: calc( 1.25 * var(--heading--font-size-h1) );
+	--branding--title--font-size-mobile: var(--heading--font-size-h1);
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);

--- a/varya/assets/sass/child-theme/variables.css
+++ b/varya/assets/sass/child-theme/variables.css
@@ -38,7 +38,7 @@
 	--global--font-size-lg: 24px;
 	--global--font-size-xl: 28px;
 	--global--font-size-xxl: 32px;
-	--global--font-size-xxxl: 64px;
+	--global--font-size-xxxl: 48px;
 	/* Line Height */
 	--global--line-height-base: 1;
 	--global--line-height-body: 1.7;
@@ -169,8 +169,8 @@
 	--branding--color-link: var(--global--color-primary);
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
-	--branding--title--font-size: var(--heading--font-size-h1);
-	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) );
+	--branding--title--font-size: calc( 1.25 * var(--heading--font-size-h1) );
+	--branding--title--font-size-mobile: var(--heading--font-size-h1);
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);

--- a/varya/assets/sass/components/header/_config.scss
+++ b/varya/assets/sass/components/header/_config.scss
@@ -3,8 +3,8 @@
 	--branding--color-link: var(--global--color-primary);
 	--branding--color-link-hover: var(--global--color-primary-hover);
 	--branding--title--font-family: var(--global--font-primary);
-	--branding--title--font-size: var(--heading--font-size-h1);
-	--branding--title--font-size-mobile: calc( 0.75 * var(--heading--font-size-h1) ); // This is a one-off calculation.
+	--branding--title--font-size: calc( 1.25 * var(--heading--font-size-h1) ); // This is a one-off calculation.
+	--branding--title--font-size-mobile: var(--heading--font-size-h1);
 	--branding--title--font-weight: 700;
 	--branding--description--font-family: var(--global--font-secondary);
 	--branding--description--font-size: var(--global--font-size-sm);


### PR DESCRIPTION
This PR makes a minor change to the largest font size used in the theme. 

It changes the largest font size variable from 64px to 48px. This feels pretty natural in scale, and also allows us to have non-ridiculously-sized text on mobile. 

Before|After
---|---
![Screen Shot 2020-06-03 at 2 46 26 PM](https://user-images.githubusercontent.com/1202812/83676669-0b8bf880-a5a9-11ea-928d-383e59b771f2.png)|![Screen Shot 2020-06-03 at 2 45 48 PM](https://user-images.githubusercontent.com/1202812/83676678-0e86e900-a5a9-11ea-9d51-d24267482dc3.png)

Before|After
---|---
![Screen Shot 2020-06-03 at 2 46 35 PM](https://user-images.githubusercontent.com/1202812/83676802-3ece8780-a5a9-11ea-8f04-4e1bc4d357fc.png)|![Screen Shot 2020-06-03 at 2 47 27 PM](https://user-images.githubusercontent.com/1202812/83676752-2cece480-a5a9-11ea-84d8-4eff2d80e72a.png)

In order to make this work nicely, it also _slightly_ changes the text size for the site header. This used 64px text on desktop before, but now it'll use 60px. The reason for this change is just so that we can get a clean pixel-perfect value through calculation (if we wanted 64px, we'd need to use `calc( 1.33 * var(--heading--font-size-h1) )`, which works out to 63.99px. 😕). 60px looks fine.  