### PR TITLE
Make site logos crisp on retina screens

### DIFF
--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -87,8 +87,8 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 		add_theme_support(
 			'custom-logo',
 			array(
-				'height'      => 120,
-				'width'       => 120,
+				'height'      => 240,
+				'width'       => 240,
 				'flex-width'  => false,
 				'flex-height' => false,
 			)


### PR DESCRIPTION
Before, the site logo images were generated at the exact size they were used, which resulted in blurry logos on retina screens. This generates them at double the normal size to fix that. 

Before:

<img width="414" alt="Screen Shot 2020-06-04 at 1 50 53 PM" src="https://user-images.githubusercontent.com/1202812/83793368-6fc2c100-a66a-11ea-9268-a966cb5bc210.png">


After: 

<img width="470" alt="Screen Shot 2020-06-04 at 1 50 20 PM" src="https://user-images.githubusercontent.com/1202812/83793358-6cc7d080-a66a-11ea-93a2-8ec7f04a4b0c.png">
