### PR TITLE
Rename "Background Light" color to "Tertiary"

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -1087,8 +1087,8 @@ pre.wp-block-verse {
 	color: var(--global--color-foreground-dark) !important;
 }
 
-.has-background-light-color[class] {
-	color: var(--global--color-background-light) !important;
+.has-tertiary-color[class] {
+	color: var(--global--color-tertiary) !important;
 }
 
 .has-background-dark-color[class] {
@@ -1134,8 +1134,8 @@ pre.wp-block-verse {
 	color: var(--global--color-background);
 }
 
-.has-background-light-background-color[class] {
-	background-color: var(--global--color-background-light) !important;
+.has-tertiary-background-color[class] {
+	background-color: var(--global--color-tertiary) !important;
 	color: var(--global--color-foreground);
 }
 
@@ -1215,35 +1215,35 @@ pre.wp-block-verse {
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-stripe-gradient-background {

--- a/seedlet/assets/css/style-woocommerce-rtl.css
+++ b/seedlet/assets/css/style-woocommerce-rtl.css
@@ -290,7 +290,7 @@ body[class*="woocommerce"] #page .woocommerce-error,
 body[class*="woocommerce"] #page .woocommerce-warning {
 	padding: var(--global--spacing-unit) calc(2 * var(--global--spacing-vertical)) var(--global--spacing-unit) var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);
-	background-color: var(--global--color-background-light);
+	background-color: var(--global--color-tertiary);
 	color: var(--global--color-foreground-dark);
 	border-top-color: var(--global--color-primary-default);
 }
@@ -486,7 +486,7 @@ body[class*="woocommerce"] #page table.shop_attributes td p {
 
 body[class*="woocommerce"] #page table.shop_attributes tr:nth-child(even) td,
 body[class*="woocommerce"] #page table.shop_attributes tr:nth-child(even) th {
-	background: var(--global--color-background-light);
+	background: var(--global--color-tertiary);
 }
 
 body[class*="woocommerce"] #page table.my_account_orders {
@@ -1059,7 +1059,7 @@ body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs {
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li {
-	background-color: var(--global--color-background-light);
+	background-color: var(--global--color-tertiary);
 	border-color: var(--wc--tabs--border-color);
 	border-top-right-radius: var(--wc--tabs--border-radius);
 	border-top-left-radius: var(--wc--tabs--border-radius);
@@ -1105,11 +1105,11 @@ body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::before, body[clas
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::before {
-	box-shadow: -2px 2px 0 var(--global--color-background-light);
+	box-shadow: -2px 2px 0 var(--global--color-tertiary);
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::after {
-	box-shadow: 2px 2px 0 var(--global--color-background-light);
+	box-shadow: 2px 2px 0 var(--global--color-tertiary);
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs::before {

--- a/seedlet/assets/css/style-woocommerce.css
+++ b/seedlet/assets/css/style-woocommerce.css
@@ -290,7 +290,7 @@ body[class*="woocommerce"] #page .woocommerce-error,
 body[class*="woocommerce"] #page .woocommerce-warning {
 	padding: var(--global--spacing-unit) var(--global--spacing-vertical) var(--global--spacing-unit) calc(2 * var(--global--spacing-vertical));
 	margin-bottom: var(--global--spacing-vertical);
-	background-color: var(--global--color-background-light);
+	background-color: var(--global--color-tertiary);
 	color: var(--global--color-foreground-dark);
 	border-top-color: var(--global--color-primary-default);
 }
@@ -486,7 +486,7 @@ body[class*="woocommerce"] #page table.shop_attributes td p {
 
 body[class*="woocommerce"] #page table.shop_attributes tr:nth-child(even) td,
 body[class*="woocommerce"] #page table.shop_attributes tr:nth-child(even) th {
-	background: var(--global--color-background-light);
+	background: var(--global--color-tertiary);
 }
 
 body[class*="woocommerce"] #page table.my_account_orders {
@@ -1059,7 +1059,7 @@ body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs {
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li {
-	background-color: var(--global--color-background-light);
+	background-color: var(--global--color-tertiary);
 	border-color: var(--wc--tabs--border-color);
 	border-top-left-radius: var(--wc--tabs--border-radius);
 	border-top-right-radius: var(--wc--tabs--border-radius);
@@ -1105,11 +1105,11 @@ body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::before, body[clas
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::before {
-	box-shadow: 2px 2px 0 var(--global--color-background-light);
+	box-shadow: 2px 2px 0 var(--global--color-tertiary);
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::after {
-	box-shadow: -2px 2px 0 var(--global--color-background-light);
+	box-shadow: -2px 2px 0 var(--global--color-tertiary);
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs::before {

--- a/seedlet/assets/css/variables-editor.css
+++ b/seedlet/assets/css/variables-editor.css
@@ -54,7 +54,7 @@ body {
 	--global--color-foreground-light: #444444;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
-	--global--color-background-light: #FAFBF6;
+	--global--color-tertiary: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #EFEFEF;
 	--global--color-text-selection: #EBF2F0;
@@ -101,7 +101,7 @@ body {
 	--button--padding-horizontal: var(--global--spacing-horizontal);
 	--cover--height: calc( 15 * var(--global--spacing-vertical) );
 	--cover--color-foreground: var(--global--color-foreground-dark);
-	--cover--color-background: var(--global--color-background-light);
+	--cover--color-background: var(--global--color-tertiary);
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: 1.3;
 	--heading--font-size-h6: var(--global--font-size-base);

--- a/seedlet/assets/css/variables.css
+++ b/seedlet/assets/css/variables.css
@@ -54,7 +54,7 @@
 	--global--color-foreground-light: #444444;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
-	--global--color-background-light: #FAFBF6;
+	--global--color-tertiary: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #EFEFEF;
 	--global--color-text-selection: #EBF2F0;
@@ -101,7 +101,7 @@
 	--button--padding-horizontal: var(--global--spacing-horizontal);
 	--cover--height: calc( 15 * var(--global--spacing-vertical) );
 	--cover--color-foreground: var(--global--color-foreground-dark);
-	--cover--color-background: var(--global--color-background-light);
+	--cover--color-background: var(--global--color-tertiary);
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: 1.3;
 	--heading--font-size-h6: var(--global--font-size-base);

--- a/seedlet/assets/sass/abstracts/_config.scss
+++ b/seedlet/assets/sass/abstracts/_config.scss
@@ -41,7 +41,7 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--color-foreground-light: #444444;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
-	--global--color-background-light: #FAFBF6;
+	--global--color-tertiary: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #EFEFEF;
 	--global--color-text-selection: #EBF2F0;

--- a/seedlet/assets/sass/blocks/cover/_config.scss
+++ b/seedlet/assets/sass/blocks/cover/_config.scss
@@ -1,5 +1,5 @@
 @mixin cover-variables() {
 	--cover--height: calc( 15 * var(--global--spacing-vertical) );
 	--cover--color-foreground: var(--global--color-foreground-dark);
-	--cover--color-background: var(--global--color-background-light);
+	--cover--color-background: var(--global--color-tertiary);
 }

--- a/seedlet/assets/sass/blocks/utilities/_editor.scss
+++ b/seedlet/assets/sass/blocks/utilities/_editor.scss
@@ -42,8 +42,8 @@
 	color: var(--global--color-foreground-dark) !important;
 }
 
-.has-background-light-color[class] {
-	color: var(--global--color-background-light) !important;
+.has-tertiary-color[class] {
+	color: var(--global--color-tertiary) !important;
 }
 
 .has-background-dark-color[class] {
@@ -92,8 +92,8 @@
 	color: var(--global--color-background);
 }
 
-.has-background-light-background-color[class] {
-	background-color: var(--global--color-background-light) !important;
+.has-tertiary-background-color[class] {
+	background-color: var(--global--color-tertiary) !important;
 	color: var(--global--color-foreground);
 }
 
@@ -177,35 +177,35 @@
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-stripe-gradient-background {

--- a/seedlet/assets/sass/blocks/utilities/_style.scss
+++ b/seedlet/assets/sass/blocks/utilities/_style.scss
@@ -130,8 +130,8 @@
 	color: var(--global--color-foreground-dark) !important;
 }
 
-.has-background-light-color[class] {
-	color: var(--global--color-background-light) !important;
+.has-tertiary-color[class] {
+	color: var(--global--color-tertiary) !important;
 }
 
 .has-background-dark-color[class] {
@@ -183,8 +183,8 @@
 	color: var(--global--color-background);
 }
 
-.has-background-light-background-color[class] {
-	background-color: var(--global--color-background-light) !important;
+.has-tertiary-background-color[class] {
+	background-color: var(--global--color-tertiary) !important;
 	color: var(--global--color-foreground);
 }
 
@@ -278,35 +278,35 @@
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-stripe-gradient-background {

--- a/seedlet/assets/sass/child-theme/variables-editor.css
+++ b/seedlet/assets/sass/child-theme/variables-editor.css
@@ -54,7 +54,7 @@ body {
 	--global--color-foreground-light: #444444;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
-	--global--color-background-light: #FAFBF6;
+	--global--color-tertiary: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #EFEFEF;
 	--global--color-text-selection: #EBF2F0;
@@ -101,7 +101,7 @@ body {
 	--button--padding-horizontal: var(--global--spacing-horizontal);
 	--cover--height: calc( 15 * var(--global--spacing-vertical) );
 	--cover--color-foreground: var(--global--color-foreground-dark);
-	--cover--color-background: var(--global--color-background-light);
+	--cover--color-background: var(--global--color-tertiary);
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: 1.3;
 	--heading--font-size-h6: var(--global--font-size-base);

--- a/seedlet/assets/sass/child-theme/variables.css
+++ b/seedlet/assets/sass/child-theme/variables.css
@@ -54,7 +54,7 @@
 	--global--color-foreground-light: #444444;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
-	--global--color-background-light: #FAFBF6;
+	--global--color-tertiary: #FAFBF6;
 	--global--color-background-dark: #DDDDDD;
 	--global--color-border: #EFEFEF;
 	--global--color-text-selection: #EBF2F0;
@@ -101,7 +101,7 @@
 	--button--padding-horizontal: var(--global--spacing-horizontal);
 	--cover--height: calc( 15 * var(--global--spacing-vertical) );
 	--cover--color-foreground: var(--global--color-foreground-dark);
-	--cover--color-background: var(--global--color-background-light);
+	--cover--color-background: var(--global--color-tertiary);
 	--heading--font-family: var(--global--font-primary);
 	--heading--line-height: 1.3;
 	--heading--font-size-h6: var(--global--font-size-base);

--- a/seedlet/assets/sass/vendors/woocommerce/components/_product-tabs.scss
+++ b/seedlet/assets/sass/vendors/woocommerce/components/_product-tabs.scss
@@ -15,7 +15,7 @@ body[class*="woocommerce"] #page { // adding #content here to override default w
 			margin-bottom: var(--global--spacing-vertical);
 
 			li {
-				background-color: var(--global--color-background-light);
+				background-color: var(--global--color-tertiary);
 				border-color: var(--wc--tabs--border-color);
 				border-top-left-radius: var(--wc--tabs--border-radius);
 				border-top-right-radius: var(--wc--tabs--border-radius);
@@ -61,11 +61,11 @@ body[class*="woocommerce"] #page { // adding #content here to override default w
 				}
 
 				&::before {
-					box-shadow: 2px 2px 0 var(--global--color-background-light);
+					box-shadow: 2px 2px 0 var(--global--color-tertiary);
 				}
 
 				&::after {
-					box-shadow: -2px 2px 0 var(--global--color-background-light);
+					box-shadow: -2px 2px 0 var(--global--color-tertiary);
 				}
 			}
 

--- a/seedlet/assets/sass/vendors/woocommerce/elements/_notices.scss
+++ b/seedlet/assets/sass/vendors/woocommerce/elements/_notices.scss
@@ -11,7 +11,7 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 	.woocommerce-warning {
 		padding: var(--global--spacing-unit) var(--global--spacing-vertical) var(--global--spacing-unit) calc(2 * var(--global--spacing-vertical));
 		margin-bottom: var(--global--spacing-vertical);
-		background-color: var(--global--color-background-light);
+		background-color: var(--global--color-tertiary);
 		color: var(--global--color-foreground-dark);
 		border-top-color: var(--global--color-primary-default);
 	}

--- a/seedlet/assets/sass/vendors/woocommerce/elements/_tables.scss
+++ b/seedlet/assets/sass/vendors/woocommerce/elements/_tables.scss
@@ -63,7 +63,7 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 
 		tr:nth-child(even) td,
 		tr:nth-child(even) th {
-			background: var(--global--color-background-light);
+			background: var(--global--color-tertiary);
 		}
 	}
 

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -22,10 +22,10 @@ class Seedlet_Custom_Colors {
 		 * Define color variables
 		 */
 		$this->seedlet_custom_color_variables = array(
+			array( '--global--color-background', '#FFFFFF', 'Background Color' ),
+			array( '--global--color-foreground', '#333333', 'Foreground Color' ),
 			array( '--global--color-primary', '#000000', 'Primary Color' ),
 			array( '--global--color-secondary', '#3C8067', 'Secondary Color' ),
-			array( '--global--color-foreground', '#333333', 'Foreground Color' ),
-			array( '--global--color-background', '#FFFFFF', 'Background Color' ),
 			array( '--global--color-tertiary', '#FAFBF6', 'Tertiary Color' ),
 			array( '--global--color-border', '#EFEFEF', 'Borders Color' )
 		);

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -26,7 +26,7 @@ class Seedlet_Custom_Colors {
 			array( '--global--color-secondary', '#3C8067', 'Secondary Color' ),
 			array( '--global--color-foreground', '#333333', 'Foreground Color' ),
 			array( '--global--color-background', '#FFFFFF', 'Background Color' ),
-			array( '--global--color-background-light', '#FAFBF6', 'Background Light Color' ),
+			array( '--global--color-tertiary', '#FAFBF6', 'Tertiary Color' ),
 			array( '--global--color-border', '#EFEFEF', 'Borders Color' )
 		);
 

--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -160,9 +160,9 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 		$foreground       = ( ! empty( $colors_theme_mod ) &&
 								'default' === $colors_theme_mod ||
 								empty( get_theme_mod( 'seedlet_--global--color-foreground' ) ) ) ? '#333333' : get_theme_mod( 'seedlet_--global--color-foreground' );
-		$background_light = ( ! empty( $colors_theme_mod ) &&
+		$tertiary = ( ! empty( $colors_theme_mod ) &&
 								'default' === $colors_theme_mod ||
-								empty( get_theme_mod( 'seedlet_--global--color-background-light' ) ) ) ? '#FAFBF6' : get_theme_mod( 'seedlet_--global--color-background-light' );
+								empty( get_theme_mod( 'seedlet_--global--color-tertiary' ) ) ) ? '#FAFBF6' : get_theme_mod( 'seedlet_--global--color-tertiary' );
 		$background       = ( ! empty( $colors_theme_mod ) &&
 								'default' === $colors_theme_mod ||
 								empty( get_theme_mod( 'seedlet_--global--color-background' ) ) ) ? '#FFFFFF' : get_theme_mod( 'seedlet_--global--color-background' );
@@ -186,9 +186,9 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 					'color' => $foreground
 				),
 				array(
-					'name'  => __( 'Background Light', 'seedlet' ),
-					'slug'  => 'background-light',
-					'color' => $background_light
+					'name'  => __( 'Tertiary', 'seedlet' ),
+					'slug'  => 'tertiary',
+					'color' => $tertiary
 				),
 				array(
 					'name'  => __( 'Background', 'seedlet' ),
@@ -199,7 +199,7 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 		);
 
 		$gradient_color_a = $secondary;
-		$gradient_color_b = $background_light;
+		$gradient_color_b = $tertiary;
 
 		add_theme_support(
 			'editor-gradient-presets',

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -2443,8 +2443,8 @@ table th,
 	color: var(--global--color-foreground-dark) !important;
 }
 
-.has-background-light-color[class] {
-	color: var(--global--color-background-light) !important;
+.has-tertiary-color[class] {
+	color: var(--global--color-tertiary) !important;
 }
 
 .has-background-dark-color[class] {
@@ -2493,8 +2493,8 @@ table th,
 	color: var(--global--color-background);
 }
 
-.has-background-light-background-color[class] {
-	background-color: var(--global--color-background-light) !important;
+.has-tertiary-background-color[class] {
+	background-color: var(--global--color-tertiary) !important;
 	color: var(--global--color-foreground);
 }
 
@@ -2685,35 +2685,35 @@ table th,
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom left, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top right, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom left, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom left, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top right, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top right, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-stripe-gradient-background {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -2456,8 +2456,8 @@ table th,
 	color: var(--global--color-foreground-dark) !important;
 }
 
-.has-background-light-color[class] {
-	color: var(--global--color-background-light) !important;
+.has-tertiary-color[class] {
+	color: var(--global--color-tertiary) !important;
 }
 
 .has-background-dark-color[class] {
@@ -2506,8 +2506,8 @@ table th,
 	color: var(--global--color-background);
 }
 
-.has-background-light-background-color[class] {
-	background-color: var(--global--color-background-light) !important;
+.has-tertiary-background-color[class] {
+	background-color: var(--global--color-tertiary) !important;
 	color: var(--global--color-foreground);
 }
 
@@ -2710,35 +2710,35 @@ table th,
  * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top left, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);
 }
 
 .has-diagonal-gradient-background {
-	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom right, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-diagonal-inverted-gradient-background {
-	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top left, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-hard-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to bottom, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-hard-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-background-light) 50%);
+	background: linear-gradient(to top, var(--global--color-secondary) 50%, var(--global--color-tertiary) 50%);
 }
 
 .has-horizontal-gradient-background {
-	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to bottom, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-horizontal-inverted-gradient-background {
-	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-background-light));
+	background: linear-gradient(to top, var(--global--color-secondary), var(--global--color-tertiary));
 }
 
 .has-stripe-gradient-background {


### PR DESCRIPTION
As suggested by @allancole in #175, this PR renames the "Background Light" color and variable to "Tertiary". Note that while testing, you may have content that refers to the old classname. This should be updated to reflect these new changes. (I don't think we need a fallback class, because the theme hasn't actually launched yet).

While I was in there, I also reordered the variables in `class-seedlet-custom-colors.php` so that they make more sense. 

Before|After
---|---
![Screen Shot 2020-06-05 at 3 26 10 PM](https://user-images.githubusercontent.com/1202812/83915404-24c7ad00-a741-11ea-883e-260d4b8a681a.png)|![Screen Shot 2020-06-05 at 3 24 19 PM](https://user-images.githubusercontent.com/1202812/83915413-272a0700-a741-11ea-9248-2fbce24bfeda.png)
